### PR TITLE
CI: Properly configure pre-commit for actionlint

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,45 @@
+---
+name: Lint GitHub Actions workflows
+
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+
+permissions: read-all
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: get_actionlint
+        # yamllint disable-line rule:line-length
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+
+  commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Requires the type to be capitlized, but accept any of the standard
+          # types
+          types: |
+            Fix
+            Feat
+            Chore
+            Docs
+            Style
+            Refactor
+            Perf
+            Test
+            Revert
+            CI
+            Build
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 ---
+ci:
+  autofix_commit_msg: "Chore: pre-commit autoupdate"
+  skip:
+    # pre-commit.ci does not have actionlint installed
+    - actionlint
+
 exclude: '^docs/conf.py'
 
 repos:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+---
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -9,8 +10,8 @@ sphinx:
   configuration: docs/conf.py
 
 # Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
+# mkdocs:
+#   configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats such as PDF
 formats:


### PR DESCRIPTION
* Disable actionlint pre-commit when run through pre-commit.ci
* Add a special verify GHA for running actionlint and validating commit
  messages since that is _also_ not run through pre-commit.ci
* Correct minor yaml formatting warning caught when getting this enabled

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
