### PR TITLE
CI: commit-message check during PR only

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,6 +22,7 @@ jobs:
 
   commit-message:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
The action being used to check the commit-message meets our Semantic
Pull Request criteria only supports happening during a pull_request or
pull_request_target event. Make sure it doesn't fire on push events.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
