### PR TITLE
Feat: Make workflow optional

### DIFF
--- a/.github/workflows/gerrit-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-required-info-yaml-verify.yaml
@@ -46,6 +46,11 @@ on:
         description: "The target GitHub repository needing the required workflow"
         required: true
         type: string
+      comment-only:
+        description: "Make this workflow advisory only, default false"
+        required: false
+        type: string
+        default: "false"
     secrets:
       GERRIT_SSH_REQUIRED_PRIVKEY:
         description: "SSH Key for the authorized user account"
@@ -60,7 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear votes
-        uses: lfit/gerrit-review-action@v0.3
+        # yamllint disable-line rule:line-length
+        uses: lfit/gerrit-review-action@6ac4c2322b68c0120a9b516eb0421491ee1b3fdf  # v0.4
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_REQUIRED_USER }}
@@ -69,6 +75,7 @@ jobs:
           gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
           gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
           vote-type: clear
+          comment-only: ${{ inputs.comment-only }}
       - name: Allow replication
         run: sleep 10s
 
@@ -131,6 +138,7 @@ jobs:
                   exit 1
               fi
           done <<< "$REPO_LIST"
+
   vote:
     if: ${{ always() }}
     # yamllint enable rule:line-length
@@ -139,7 +147,8 @@ jobs:
     steps:
       - uses: technote-space/workflow-conclusion-action@v3
       - name: Set vote
-        uses: lfit/gerrit-review-action@v0.3
+        # yamllint disable-line rule:line-length
+        uses: lfit/gerrit-review-action@6ac4c2322b68c0120a9b516eb0421491ee1b3fdf  # v0.4
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_REQUIRED_USER }}
@@ -148,3 +157,4 @@ jobs:
           gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
           gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
           vote-type: ${{ env.WORKFLOW_CONCLUSION }}
+          comment-only: ${{ inputs.comment-only }}


### PR DESCRIPTION
Make it so that the workflow can be setup to just do advisory
(non-voting) jobs. This makes it easier to enable and not block until
such time as it's time to fully enable it.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
