### PR TITLE
Feat: Add packer verify Github Actions to workflow

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -1,0 +1,156 @@
+---
+name: Packer verify
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      comment-only:
+        description: "Make this workflow advisory only, default false"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      CLOUDS_ENV_B64:
+        description: "Packer cloud environment credentials"
+        required: true
+      CLOUDS_YAML_B64:
+        description: "Openstack cloud environment credentials"
+        required: true
+
+env:
+  OS_CLOUD: "vex"
+  PACKER_VERSION: "1.9.1"
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: compose-packer-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  packer-validator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lfit/checkout-gerrit-change-action@v0.4
+        with:
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          delay: "0s"
+      - name: Clone git submodules
+        run: git submodule update --init
+      - name: Setup packer
+        uses: hashicorp/setup-packer@main
+        id: setup
+        with:
+          version: ${{ env.PACKER_VERSION }}
+      - name: Create cloud-env file required for packer
+        id: create-cloud-env-file
+        shell: bash
+        run: |
+          echo "${{ secrets.CLOUDS_ENV_B64 }}" | base64 --decode \
+                  > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
+      - name: Create cloud.yaml file for openstack client
+        id: create-cloud-yaml-file
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.config/openstack"
+          echo "${{ secrets.CLOUDS_YAML_B64 }}" | base64 --decode \
+                  > "$HOME/.config/openstack/clouds.yaml"
+      - uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: "3.11"
+      - name: Install openstack deps
+        id: install-openstack-deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install python-openstackclient
+          pip freeze
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          base: ${{ inputs.GERRIT_BRANCH }}
+          ref: ${{ inputs.GERRIT_PATCHSET_REVISION }}
+          filters: |
+            src:
+              - 'packer/**'
+      - if: steps.changes.outputs.src == 'true'
+        run: |
+          set -x
+          cd packer
+
+          varfiles=(common-packer/vars/*.pkrvars.hcl)
+          templates=(templates/*.pkr.hcl)
+
+          mkdir -p "${GITHUB_WORKSPACE}/logs"
+          PACKER_LOGS_DIR="${GITHUB_WORKSPACE}/logs"
+
+          for varfile in "${varfiles[@]}"; do
+              if [[ "$varfile" == *"cloud-env.json"* ]] || \
+                 [[ "$varfile" == "vars/*.json" ]] || \
+                 [[ "$varfile" == *"cloud-env.pkrvars.hcl"* ]] || \
+                 [[ "$varfile" == *"cloud-env-aws.pkrvars.hcl"* ]] || \
+                 [[ "$varfile" == "vars/*.pkrvars.hcl" ]]; then
+                  continue
+              fi
+
+              echo "-----> Test var: $varfile"
+              for template in "${templates[@]}"; do
+                  if [[ "$template" == *"variables.pkr.hcl"* ]] || \
+                     [[ "$template" == *"variables.auto.pkr.hcl"* ]]; then
+                      continue
+                  fi
+
+                  if [[ "${template#*.}" == "pkr.hcl" ]]; then
+                      echo "packer init $template ..."
+                      packer init "$template"
+                  fi
+
+                  LOG_FILE="packer-validate-${varfile##*/}-${template##*/}.log"
+                  export PACKER_LOG="yes"
+                  export PACKER_LOG_PATH="$PACKER_LOGS_DIR/$LOG_FILE"
+                  if output=$(OS_CLOUD=${{ env.OS_CLOUD }} packer validate \
+                        -var-file="${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl" \
+                        -var-file="$varfile" "$template"); then
+                      echo "$template: $output"
+                  else
+                      echo "$template: $output"
+                      exit 1
+                  fi
+              done
+          done


### PR DESCRIPTION
- Update build params with defaults params to be able to run workflows manually on a forked repo.
- Installs the default version of packer to v1.9.1
- Use the latest version v0.4 lfit/checkout-gerrit-change-action allow passing the GHA PAT token for all the jobs in the workflow file.
- Use base64 encode / decode to handle special characters correctly while storing and retriving secrets to/from GHA. Writing secrets CLI dependent config files results in an undefined behavior.
- The change requires creating secrets before hand on project with secret name as CLOUDS_YAML_B64 and CLOUDS_ENV_B64 along with the $key-value pairs in yaml and hcl format and base64 encoded.