### PR TITLE
CI: Add additional info to concurrency

### DIFF
--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -50,7 +50,8 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  # yamllint disable-line rule:line-length
+  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -47,7 +47,8 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  # yamllint disable-line rule:line-length
+  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-required-info-yaml-verify.yaml
@@ -57,7 +57,8 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  # yamllint disable-line rule:line-length
+  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
To protect against multiple workflows for the same ChangeID possibly
trampling on each other we need to make sure that we have unique
information in the concurrency group

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
