### PR TITLE
Feat: Create basic repo linting workflow compose

### DIFF
--- a/.github/workflows/compose-repo-linting.yaml
+++ b/.github/workflows/compose-repo-linting.yaml
@@ -1,0 +1,95 @@
+---
+name: Compose Repository Linting
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      pre_commit_skips:
+        description: >
+          Comma separated list of pre-commit validators to skip, defaults to
+          actionlint
+        required: false
+        type: string
+        default: "actionlint"
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: compose-repo-linting-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gerrit Checkout
+        # yamllint disable-line rule:line-length
+        uses: lfit/checkout-gerrit-change-action@70360ca2f8bee3e6a15224d8a03f8e017b1ac91f  # v0.4
+        with:
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          delay: "0s"
+      - name: Download actionlint
+        id: get_actionlint
+        # yamllint disable-line rule:line-length
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+
+  # run pre-commit tox env separately to get use of more parallel processing
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gerrit Checkout
+        # yamllint disable-line rule:line-length
+        uses: lfit/checkout-gerrit-change-action@70360ca2f8bee3e6a15224d8a03f8e017b1ac91f  # v0.4
+        with:
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          delay: "0s"
+      - name: Setup Python
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1  # v4.7.0
+        with:
+          python-version: "3.11"
+      - name: Run static analysis and format checkers
+        # yamllint disable-line rule:line-length
+        run: SKIP=${{ inputs.pre_commit_skips }} pipx run pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
We have a common workflow of validating actionlint and pre-commit on any
repositories as two separate jobs inside the workflow. This will allow
this to be more modular

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
