### PR TITLE
Refactor: Re-arrange compose-packer-verify

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -41,11 +41,6 @@ on:
         description: "Gerrit refspec of change"
         required: true
         type: string
-      comment-only:
-        description: "Make this workflow advisory only, default false"
-        required: false
-        type: string
-        default: "false"
     secrets:
       CLOUDS_ENV_B64:
         description: "Packer cloud environment credentials"
@@ -63,45 +58,24 @@ concurrency:
   group: compose-packer-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   packer-validator:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.4
+      - name: Gerrit Checkout
+        # yamllint disable-line rule:line-length
+        uses: lfit/checkout-gerrit-change-action@70360ca2f8bee3e6a15224d8a03f8e017b1ac91f  # v0.4
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
       - name: Clone git submodules
+        shell: bash
         run: git submodule update --init
-      - name: Setup packer
-        uses: hashicorp/setup-packer@main
-        id: setup
-        with:
-          version: ${{ env.PACKER_VERSION }}
-      - name: Create cloud-env file required for packer
-        id: create-cloud-env-file
-        shell: bash
-        run: |
-          echo "${{ secrets.CLOUDS_ENV_B64 }}" | base64 --decode \
-                  > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
-      - name: Create cloud.yaml file for openstack client
-        id: create-cloud-yaml-file
-        shell: bash
-        run: |
-          mkdir -p "$HOME/.config/openstack"
-          echo "${{ secrets.CLOUDS_YAML_B64 }}" | base64 --decode \
-                  > "$HOME/.config/openstack/clouds.yaml"
-      - uses: actions/setup-python@v4
-        id: setup-python
-        with:
-          python-version: "3.11"
-      - name: Install openstack deps
-        id: install-openstack-deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install python-openstackclient
-          pip freeze
-      - uses: dorny/paths-filter@v2
+      - name: Check for changes
+        # yamllint disable-line rule:line-length
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # v2.11.1
         id: changes
         with:
           base: ${{ inputs.GERRIT_BRANCH }}
@@ -109,7 +83,44 @@ jobs:
           filters: |
             src:
               - 'packer/**'
-      - if: steps.changes.outputs.src == 'true'
+      - name: Setup packer
+        if: steps.changes.outputs.src == 'true'
+        uses: hashicorp/setup-packer@main
+        id: setup
+        with:
+          version: ${{ env.PACKER_VERSION }}
+      - name: Create cloud-env file required for packer
+        id: create-cloud-env-file
+        if: steps.changes.outputs.src == 'true'
+        shell: bash
+        run: |
+          echo "${{ secrets.CLOUDS_ENV_B64 }}" | base64 --decode \
+                  > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
+      - name: Create cloud.yaml file for openstack client
+        id: create-cloud-yaml-file
+        if: steps.changes.outputs.src == 'true'
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.config/openstack"
+          echo "${{ secrets.CLOUDS_YAML_B64 }}" | base64 --decode \
+                  > "$HOME/.config/openstack/clouds.yaml"
+      - name: Setup Python
+        if: steps.changes.outputs.src == 'true'
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1  # v4.7.0
+        with:
+          python-version: "3.11"
+      - name: Install openstack deps
+        id: install-openstack-deps
+        if: steps.changes.outputs.src == 'true'
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install python-openstackclient
+          pip freeze
+      - name: Verify packer files
+        if: steps.changes.outputs.src == 'true'
+        shell: bash
         run: |
           set -x
           cd packer


### PR DESCRIPTION
* Re-order the job so that it checks to see if packer files have changed
  before doing any other work.
* Limit token permissions to just read
* Give all steps a name

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
