### PR TITLE
CI: Add output grouping for packer

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -140,6 +140,7 @@ jobs:
                   continue
               fi
 
+              echo "::group::$varfile"
               echo "-----> Test var: $varfile"
               for template in "${templates[@]}"; do
                   if [[ "$template" == *"variables.pkr.hcl"* ]] || \
@@ -164,4 +165,5 @@ jobs:
                       exit 1
                   fi
               done
+              echo "::endgroup::"
           done


### PR DESCRIPTION
GitHub Actions makes it possible to do collapsed log lines with some
echod commands to the runner. This makes the logs easier to read.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
