### PR TITLE
Chore: Upgrade Gerrit checkout to v0.5

### DIFF
--- a/.github/workflows/compose-jjb-verify.yaml
+++ b/.github/workflows/compose-jjb-verify.yaml
@@ -55,17 +55,16 @@ jobs:
     steps:
       - name: Gerrit Checkout
         # yamllint disable-line rule:line-length
-        uses: lfit/checkout-gerrit-change-action@70360ca2f8bee3e6a15224d8a03f8e017b1ac91f  # v0.4
+        uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
+          submodules: "true"
       - name: Setup Python
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1  # v4.7.0
         with:
           python-version: "3.11"
-      - name: Clone git submodules
-        run: git submodule update --init
       - name: Run JJB Verify
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/compose-repo-linting.yaml
+++ b/.github/workflows/compose-repo-linting.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Gerrit Checkout
         # yamllint disable-line rule:line-length
-        uses: lfit/checkout-gerrit-change-action@70360ca2f8bee3e6a15224d8a03f8e017b1ac91f  # v0.4
+        uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Gerrit Checkout
         # yamllint disable-line rule:line-length
-        uses: lfit/checkout-gerrit-change-action@70360ca2f8bee3e6a15224d8a03f8e017b1ac91f  # v0.4
+        uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"

--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -80,12 +80,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
+          submodules: "true"
       - uses: actions/setup-python@v4
         id: setup-python
         with:
           python-version: "3.11"
-      - name: Clone git submodules
-        run: git submodule update --init
       - name: Run JJB Merge
         env:
           JJB_WORKERS: ${{ vars.JJB_WORKERS }}

--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -72,7 +72,8 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.3
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
@@ -90,7 +91,8 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.3
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
@@ -104,16 +106,16 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.3
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
+          submodules: "true"
       - uses: actions/setup-python@v4
         id: setup-python
         with:
           python-version: "3.11"
-      - name: Clone git submodules
-        run: git submodule update --init
       - name: Run JJB Verify
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/gerrit-compose-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-compose-ci-management-verify.yaml
@@ -55,7 +55,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.4
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
@@ -72,7 +73,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.4
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
@@ -85,16 +87,16 @@ jobs:
   jjb-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.4
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"
+          submodules: "true"
       - uses: actions/setup-python@v4
         id: setup-python
         with:
           python-version: "3.11"
-      - name: Clone git submodules
-        run: git submodule update --init
       - name: Run JJB Verify
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/gerrit-compose-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-info-yaml-verify.yaml
@@ -60,7 +60,8 @@ jobs:
   info-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.4
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"

--- a/.github/workflows/gerrit-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-required-info-yaml-verify.yaml
@@ -84,7 +84,8 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: lfit/checkout-gerrit-change-action@v0.4
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           delay: "0s"


### PR DESCRIPTION
* Upgrade to v0.5 with frozen SHA
* Use new submodules directive where possible to save a step
* Add needed linting lines for new long lines

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
