### PR TITLE
Fix: Use python 3.8 for docs to match the Jenkins verification.

### DIFF
--- a/.github/workflows/compose-rtdv3-verify.yaml
+++ b/.github/workflows/compose-rtdv3-verify.yaml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: "3.11"
+          python-version: "3.8"
       - name: Verify If readthedocs Config exists
         run: |
           echo "Verifying if readthedocs.yaml config file exists"


### PR DESCRIPTION
Once this is confirmed to be working, we can ask the teams to migrate docs to 3.11