### PR TITLE
CI: Unpin urllib3<2.0.0 with JJB 5.0.4

### DIFF
--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -92,8 +92,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install jenkins-job-builder
-          # urllib3 needs to be pinned to avoid timeouts
-          pip install --upgrade urllib3~=1.26.15
           mkdir -p "${GITHUB_WORKSPACE}/.config/jenkins_jobs"
           cat << EOF > "${GITHUB_WORKSPACE}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]


### PR DESCRIPTION
The latest version of python-jenkins 1.8.1 and JJB 5.0.4 support urllib3 newer DEFAULT_TIMEOUT, therefore unpin urllib3<2.0.0