### PR TITLE
CI: Update rtdv3 verify and merge workflows

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -41,6 +41,12 @@ on:
         description: "Gerrit refspec of change"
         required: true
         type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: false
+        default: ${{ github.repository }}
+        type: string
     secrets:
       RTD_TOKEN:
         description: "RTD API user token"

--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -41,6 +41,12 @@ on:
         description: "Gerrit refspec of change"
         required: true
         type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: false
+        default: ${{ github.repository }}
+        type: string
     secrets:
       RTD_TOKEN:
         description: "RTD API user token"


### PR DESCRIPTION
Allow the rtdv3 workflows to be used as required or be used at the repository level.