### PR TITLE
Fix: Restructure rtdv3 merge job

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -67,29 +67,13 @@ env:
   MASTER_RTD_PROJECT: doc
 
 jobs:
-  rtd-verify:
-    # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml@main
-    with:
-      GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
-      GERRIT_CHANGE_ID: ${{ inputs.GERRIT_CHANGE_ID }}
-      GERRIT_CHANGE_NUMBER: ${{ inputs.GERRIT_CHANGE_NUMBER }}
-      GERRIT_CHANGE_URL: ${{ inputs.GERRIT_CHANGE_URL }}
-      GERRIT_EVENT_TYPE: ${{ inputs.GERRIT_EVENT_TYPE }}
-      GERRIT_PATCHSET_NUMBER: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
-      GERRIT_PATCHSET_REVISION: ${{ inputs.GERRIT_PATCHSET_REVISION }}
-      GERRIT_PROJECT: ${{ inputs.GERRIT_PROJECT }}
-      GERRIT_REFSPEC: ${{ inputs.GERRIT_REFSPEC }}
-    secrets:
-      RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
-
   rtd-merge:
     runs-on: ubuntu-latest
-    needs: rtd-verify
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
+          repository: ${{ inputs.GERRIT_PROJECT }}
           submodules: "true"
       - uses: actions/setup-python@v4
         id: setup-python


### PR DESCRIPTION
- Do not re-run verify on rtdv3 merge workflow
- Clone the caller repo not the local one