### PR TITLE
Chore: Upgrade gerrit checkout

### DIFF
--- a/.github/workflows/compose-repo-linting.yaml
+++ b/.github/workflows/compose-repo-linting.yaml
@@ -60,9 +60,11 @@ jobs:
     steps:
       - name: Gerrit Checkout
         # yamllint disable-line rule:line-length
-        uses: lfit/checkout-gerrit-change-action@c70c41f86f57a62ae26ac17b4f16516212c46222  # v0.5
+        uses: lfit/checkout-gerrit-change-action@57bf0435f739fbbc7ce4cc85c9c3b8a386c6f84b  # v0.6
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-project: ${{ inputs.GERRIT_PROJECT }}
+          gerrit-url: ${{ vars.GERRIT_URL }}
           delay: "0s"
       - name: Download actionlint
         id: get_actionlint


### PR DESCRIPTION
Upgrade gerrit checkout where it hadn't been yet

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
