### PR TITLE
Fix: Remove extra space passed to system property

### DIFF
--- a/.github/workflows/gerrit-compose-required-maven-nexus-iq.yaml
+++ b/.github/workflows/gerrit-compose-required-maven-nexus-iq.yaml
@@ -101,7 +101,7 @@ jobs:
           phases: clean, install, dependency:tree com.sonatype.clm:clm-maven-plugin:2.41.0-02:index
           settings-file: settings.xml
           # yamllint disable-line rule:line-length
-          maven-opts: --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer .Slf4jMavenTransferListener=warn -Dmaven.repo.local=/tmp/r -Dorg.ops4j.pax.url.mvn.localRepository=/tmp/r -DaltDeploymentRepository=staging::default::file:"${GITHUB_WORKSPACE}"/m2repo
+          maven-opts: --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.repo.local=/tmp/r -Dorg.ops4j.pax.url.mvn.localRepository=/tmp/r -DaltDeploymentRepository=staging::default::file:"${GITHUB_WORKSPACE}"/m2repo
       - name: Nexus IQ Policy Evaluation
         uses: sonatype-nexus-community/iq-github-action@master
         with:


### PR DESCRIPTION
Remove extra space typo while passing the maven transfer listener property.