### PR TITLE
Fix: Strip carrot symbol from the settings file

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -122,6 +122,7 @@ jobs:
               CI_REPO="ci-management"
           fi
           wget -q -O settings.xml "https://raw.githubusercontent.com/${{ vars.ORGANIZATION }}/${CI_REPO}/master/jenkins-config/managed-config-files/globalMavenSettings/global-settings/content"
+          sed -i 's#\^${#${#' settings.xml
         # yamllint enable rule:line-length
       - name: Build code with Maven
         # yamllint disable rule:line-length


### PR DESCRIPTION
The carrot symbol ('^') set in Jenkins maven settings.xml file
(ci-man/jenkins-config/managed-config-files/globalMavenSettings)
is used for escaping the '${}' by the JCASC plugin scripts.

Maven does not recognize these symbols. Therefore the file needs
to be processed to remove the prefixed carrot symbol before its
used in GHA workflow or would return the below error while
resolving dependencies.

Error:
Cannot access
^https://nexus.opendaylight.org/content/repositories/public/