### PR TITLE
Fix: Pass secrets and vars thru env

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -41,6 +41,18 @@ on:
         description: "Gerrit refspec of change"
         required: true
         type: string
+      ENV_VARS:
+        # yamllint disable-line rule:line-length
+        description: "Pass GitHub variables to be exported as environment variables via `toJSON(vars)` or specific variables encoded in JSON format"
+        required: false
+        default: "{}"
+        type: string
+      ENV_SECRETS:
+        # yamllint disable-line rule:line-length
+        description: "Pass GitHub secrets to be exported as environment variables via `toJSON(secrets)` or specific secrets encoded in JSON format"
+        required: false
+        default: "{}"
+        type: string
     secrets:
       CLOUDS_ENV_B64:
         description: "Packer cloud environment credentials"
@@ -87,13 +99,23 @@ jobs:
         id: setup
         with:
           version: ${{ env.PACKER_VERSION }}
+      - name: Export env variables
+        if: steps.changes.outputs.src == 'true'
+        uses: infovista-opensource/vars-to-env-action@1.0.0
+        with:
+          secrets: ${{ inputs.ENV_VARS }}
+      - name: Export env secrets
+        if: steps.changes.outputs.src == 'true'
+        uses: infovista-opensource/vars-to-env-action@1.0.0
+        with:
+          secrets: ${{ inputs.ENV_SECRETS }}
       - name: Create cloud-env file required for packer
         id: create-cloud-env-file
         if: steps.changes.outputs.src == 'true'
         shell: bash
         # yamllint disable rule:line-length
         run: |
-          echo "${{ secrets.CLOUDS_ENV_B64 }}" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
+          echo "${{ env.CLOUDS_ENV_B64 }}" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
         # yamllint enable rule:line-length
       - name: Create cloud.yaml file for openstack client
         id: create-cloud-yaml-file
@@ -102,7 +124,7 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           mkdir -p "$HOME/.config/openstack"
-          echo "${{ secrets.CLOUDS_YAML_B64 }}" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
+          echo "${{ env.CLOUDS_YAML_B64 }}" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
         # yamllint enable rule:line-length
       - name: Setup Python
         if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -131,7 +131,9 @@ jobs:
       GERRIT_PATCHSET_REVISION: ${{ inputs.GERRIT_PATCHSET_REVISION }}
       GERRIT_PROJECT: ${{ inputs.GERRIT_PROJECT }}
       GERRIT_REFSPEC: ${{ inputs.GERRIT_REFSPEC }}
+      ENV_VARS: ${{ toJSON(vars) }}
     secrets:
+      ENV_SECRETS: ${{ toJSON(secrets) }}
       CLOUDS_ENV_B64: ${{ secrets.CLOUDS_ENV_B64 }}
       CLOUDS_YAML_B64: ${{ secrets.CLOUDS_ENV_B64 }}
 


### PR DESCRIPTION
Passing secrets through nested composable workflows may potentially by reseting the values causing unmarshall errors.