### PR TITLE
CI: Define ENV_SECRETS in workflow

### DIFF
--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -46,6 +46,18 @@ on:
         required: false
         type: string
         default: "false"
+      ENV_VARS:
+        # yamllint disable-line rule:line-length
+        description: "Pass GitHub variables to be exported as environment variables via `toJSON(vars)` or specific variables encoded in JSON format"
+        required: false
+        default: "{}"
+        type: string
+      ENV_SECRETS:
+        # yamllint disable-line rule:line-length
+        description: "Pass GitHub secrets to be exported as environment variables via `toJSON(secrets)` or specific secrets encoded in JSON format"
+        required: false
+        default: "{}"
+        type: string
     secrets:
       GERRIT_SSH_PRIVKEY:
         description: "SSH Key for the authorized user account"


### PR DESCRIPTION
Error:
The workflow is not valid. composed-ci-management-verify.yaml@main (Line: 136, Col: 20): Invalid secret, ENV_SECRETS is not defined in the referenced workflow.