### PR TITLE
Fix: mask sensitive info with ::add-masks::

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -113,7 +113,8 @@ jobs:
         shell: bash
         # yamllint disable rule:line-length
         run: |
-          echo "${{ env.CLOUDS_ENV_B64 }}" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
+          clouds_env_b64="${{ env.CLOUDS_ENV_B64 }}"
+          echo "::add-mask::$clouds_env_b64" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
         # yamllint enable rule:line-length
       - name: Create cloud.yaml file for openstack client
         id: create-cloud-yaml-file
@@ -122,7 +123,8 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           mkdir -p "$HOME/.config/openstack"
-          echo "${{ env.CLOUDS_YAML_B64 }}" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
+          clouds_yaml_b64="${{ env.CLOUDS_YAML_B64 }}"
+          echo "::add-mask::$clouds_yaml_b64" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
         # yamllint enable rule:line-length
       - name: Setup Python
         if: steps.changes.outputs.src == 'true'


### PR DESCRIPTION
A workaround to mask printing sensitive info from
workflow logs.