### PR TITLE
CI: Move input param ENV_SECRETS under secrets

### DIFF
--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -52,13 +52,11 @@ on:
         required: false
         default: "{}"
         type: string
+    secrets:
       ENV_SECRETS:
         # yamllint disable-line rule:line-length
         description: "Pass GitHub secrets to be exported as environment variables via `toJSON(secrets)` or specific secrets encoded in JSON format"
         required: false
-        default: "{}"
-        type: string
-    secrets:
       GERRIT_SSH_PRIVKEY:
         description: "SSH Key for the authorized user account"
         required: true


### PR DESCRIPTION
This is done to ensure the env printed in the workflow logs does not contain sensitive data.