### PR TITLE
Fix: Pin JJB to 5.1.0

### DIFF
--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -91,7 +91,7 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder
+          pip install jenkins-job-builder==5.1.0
           mkdir -p "${GITHUB_WORKSPACE}/.config/jenkins_jobs"
           cat << EOF > "${GITHUB_WORKSPACE}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]

--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -128,7 +128,7 @@ jobs:
       - name: Run JJB Verify
         run: |
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder
+          pip install jenkins-job-builder==5.1.0
           mkdir -p "${HOME}/.config/jenkins_jobs"
           cat << EOF > "${HOME}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]

--- a/.github/workflows/gerrit-compose-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-compose-ci-management-verify.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Run JJB Verify
         run: |
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder
+          pip install jenkins-job-builder==5.1.0
           mkdir -p "${HOME}/.config/jenkins_jobs"
           cat << EOF > "${HOME}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]


### PR DESCRIPTION
JJB 6.0.0 is release and our ci-man repos are broken. Pin to the latest working version until our code base is updated with the latest backard incompatibilites.