### PR TITLE
Fix: RTD job breakage due to missing dependency

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}
         run: |
           python -m pip install --upgrade pip
-          pip install lftools 'niet~=1.4.2' 'cryptography<3.4' yq tox
+          pip install lftools 'niet~=1.4.2' 'cryptography<3.4' yq tox six
           # urllib3 needs to be pinned to avoid timeouts
           pip install --upgrade urllib3~=1.26.15
       - name: Running tox


### PR DESCRIPTION
Add missing "six" package to this workflow to address breakage here:
https://jira.linuxfoundation.org/browse/IT-26426
https://github.com/onap/.github/actions/runs/7714805162/job/21027916726