### PR TITLE
Chore: Update actions/checkout to v4

### DIFF
--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: notify
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           submodules: "true"

--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -70,7 +70,7 @@ jobs:
   rtd-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           repository: ${{ inputs.TARGET_REPO }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,7 +8,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download actionlint
         id: get_actionlint
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
Update: actions/checkout@v3 -> actions/checkout@v4
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`