### PR TITLE
Fix: Revert dependency package install for RTD

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}
         run: |
           python -m pip install --upgrade pip
-          pip install lftools 'niet~=1.4.2' 'cryptography<3.4' yq tox six
+          pip install lftools 'niet~=1.4.2' 'cryptography<3.4' yq tox
           # urllib3 needs to be pinned to avoid timeouts
           pip install --upgrade urllib3~=1.26.15
       - name: Running tox


### PR DESCRIPTION
This reverts commit db666d63690ef243fb702b368a7aaf94cb3e36e3.