### PR TITLE
CI: Allow JJB version to be set through vars

### DIFF
--- a/.github/workflows/compose-jjb-verify.yaml
+++ b/.github/workflows/compose-jjb-verify.yaml
@@ -66,9 +66,13 @@ jobs:
         with:
           python-version: "3.11"
       - name: Run JJB Verify
+        env:
+          JJB_VERSION: ${{ vars.JJB_VERSION }}
+        # yamllint disable rule:line-length
         run: |
+          jjb_version="${JJB_VERSION:-5.1.0}"
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder
+          pip install jenkins-job-builder==5.1.0
           mkdir -p "${HOME}/.config/jenkins_jobs"
           cat << EOF > "${HOME}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]

--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -87,11 +87,13 @@ jobs:
           python-version: "3.11"
       - name: Run JJB Merge
         env:
+          JJB_VERSION: ${{ vars.JJB_VERSION }}
           JJB_WORKERS: ${{ vars.JJB_WORKERS }}
         # yamllint disable rule:line-length
         run: |
+          jjb_version="${JJB_VERSION:-5.1.0}"
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder==5.1.0
+          pip install jenkins-job-builder=="$jjb_version"
           mkdir -p "${GITHUB_WORKSPACE}/.config/jenkins_jobs"
           cat << EOF > "${GITHUB_WORKSPACE}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]

--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -126,9 +126,13 @@ jobs:
         with:
           python-version: "3.11"
       - name: Run JJB Verify
+        env:
+          JJB_VERSION: ${{ vars.JJB_VERSION }}
+        # yamllint disable rule:line-length
         run: |
+          jjb_version="${JJB_VERSION:-5.1.0}"
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder==5.1.0
+          pip install jenkins-job-builder=="$jjb_version"
           mkdir -p "${HOME}/.config/jenkins_jobs"
           cat << EOF > "${HOME}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]

--- a/.github/workflows/gerrit-compose-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-compose-ci-management-verify.yaml
@@ -107,9 +107,13 @@ jobs:
         with:
           python-version: "3.11"
       - name: Run JJB Verify
+        env:
+          JJB_VERSION: ${{ vars.JJB_VERSION }}
+        # yamllint disable rule:line-length
         run: |
+          jjb_version="${JJB_VERSION:-5.1.0}"
           python -m pip install --upgrade pip
-          pip install jenkins-job-builder==5.1.0
+          pip install jenkins-job-builder=="$jjb_version"
           mkdir -p "${HOME}/.config/jenkins_jobs"
           cat << EOF > "${HOME}/.config/jenkins_jobs/jenkins_jobs.ini"
           [job_builder]


### PR DESCRIPTION
The present implementation becomes a bottleneck while upgrading ci-man repos to JJB 6.x since all downstream repos cannot be upgraded at the same time.

Set the default version of JJB version as "5.1.0".

Issue: RELENG-5122