### PR TITLE
Fix: Use actions/checkout for ref to local action

### DIFF
--- a/.github/workflows/gerrit-compose-required-tox-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-tox-verify.yaml
@@ -92,7 +92,7 @@ jobs:
         tox-env: ${{ fromJSON(inputs.TOX_ENVS) }}
 
     steps:
-      - name: Gerrit Checkout
+      - name: Gerrit checkout
         # yamllint disable-line rule:line-length
         uses: lfit/checkout-gerrit-change-action@95c493e8fd60233fac7b9c99ebe5f60e9a8c555b  # v0.7
         with:
@@ -102,6 +102,8 @@ jobs:
           delay: "0s"
           repository: ${{ inputs.TARGET_REPO }}
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+      - name: Actions checkout  # Needed for local action reference
+        uses: actions/checkout@v4
       - name: Run tox
         uses: ./.github/actions/tox-run-action
         with:


### PR DESCRIPTION
This is poorly documented, but it is necessary to do this specific checkout step before using a local action.

This should fix the error seen here: https://github.com/o-ran-sc/sim-a1-interface/actions/runs/7875295910/job/21486885240