### PR TITLE
Fix: Specify remote repo and local path for action

### DIFF
--- a/.github/workflows/gerrit-compose-required-tox-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-tox-verify.yaml
@@ -104,8 +104,12 @@ jobs:
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
       - name: Actions checkout  # Needed for local action reference
         uses: actions/checkout@v4
+        with:
+          repository: lfit/releng-reusable-workflows
+          sparse-checkout: .github/actions/tox-run-action
+          path: reusable-tox-run-action
       - name: Run tox
-        uses: ./.github/actions/tox-run-action
+        uses: ./reusable-tox-run-action/.github/actions/tox-run-action
         with:
           tox-dir: ${{ inputs.TOX_DIR }}
           py-version: ${{ inputs.PYTHON_VERSION }}


### PR DESCRIPTION
The tox-run action needs to be checked out into a separate directory, and then referred to with its full path. This makes external repos capable of running the action, as it will no longer be local for the calling project.