### PR TITLE
Fix: Remove "cache: pip" from setup-python call

### DIFF
--- a/.github/actions/tox-run-action/action.yaml
+++ b/.github/actions/tox-run-action/action.yaml
@@ -30,7 +30,6 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.py-version }}
-        cache: pip
     - name: Run pre-build-script
       id: pre-build
       if: ${{ hashFiles(inputs.pre-build-script) }}
@@ -48,6 +47,10 @@ runs:
       run: |
         cd "${GITHUB_WORKSPACE}/${{ inputs.tox-dir }}" || exit 1
 
+        if [[ -f "requirements.txt" ]]; then
+            pip install -r requirements.txt
+        fi
+
         TOX_OPTIONS_LIST=""
         if [[ -n ${{ inputs.tox-envs }} ]]; then
             TOX_OPTIONS_LIST=" -e ${{ inputs.tox-envs }}"
@@ -56,4 +59,5 @@ runs:
         # $TOX_OPTIONS_LIST are intentionally not surrounded by quotes
         # to correcly pass options to tox
         # shellcheck disable=SC2086
+        pipx run --python '${{ steps.setup-python.outputs.python-path }}' \
         tox --parallel ${{ inputs.parallel }} --parallel-live $TOX_OPTIONS_LIST


### PR DESCRIPTION
This is a convenient way to get requirements installed, but requires either requirements.txt or pyproject.toml to be present. Since we don't want the action to fail if these are not present, we can't use it here. Instead, the build-package step will install pyproject.toml requirements, and we will now check for a requirements.txt file while running the shell script that calls tox.

This also adds pipx to the tox call, to ensure that tox and its requirements are present to run tox properly.