### PR TITLE
Fix: Update MVN_PHASES to remove comma separated goals

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -59,7 +59,7 @@ on:
       MVN_PHASES:
         description: "Comma separated list of phases to execute"
         required: false
-        default: "clean, deploy"
+        default: "clean deploy"
         type: string
       MVN_OPTS:
         description: "Maven options"


### PR DESCRIPTION
The comma was previously needed for the maven action we were using. We should have space separated goals.