### PR TITLE
Fix: Only obtain global-settings through variable

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -129,22 +129,10 @@ jobs:
         uses: infovista-opensource/vars-to-env-action@1.0.0
         with:
           secrets: ${{ inputs.ENV_SECRETS }}
-      - name: Obtain global settings file
-        # yamllint disable rule:line-length
-        run: |
-          if [[ "${{ vars.ORGANIZATION }}" == "opendaylight" ]]; then
-              CI_REPO="releng-builder"
-          else
-              CI_REPO="ci-management"
-          fi
-          wget -q -O settings.xml "https://raw.githubusercontent.com/${{ vars.ORGANIZATION }}/${CI_REPO}/master/jenkins-config/managed-config-files/globalMavenSettings/global-settings/content"
-          sed -i 's#\^${#${#' settings.xml
-        # yamllint enable rule:line-length
       - name: Build code with Maven
         # yamllint disable rule:line-length
         run: |
-          touch global-settings.xml
-          echo "${{ vars.GLOBAL_SETTINGS }}" >> global-settings.xml
+          echo "${{ vars.GLOBAL_SETTINGS }}" > global-settings.xml
           echo "Maven build starting"
 
           cat global-settings.xml


### PR DESCRIPTION
Currently, the global-settings are obtained through a Jenkins fetch, and then via a variable which is concatenated onto what was fetched. This is a problem, as it will create an invalid settings file if both are defined.

To simplify this process, we can simply use the variable. The touch/cat is replaced with an overwrite, as we want the file to be written as it's stored, and not placed on top of anything that is already in the file.