### PR TITLE
Fix: Use single quotes for global-settings echo

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: Build code with Maven
         # yamllint disable rule:line-length
         run: |
-          echo "${{ vars.GLOBAL_SETTINGS }}" > global-settings.xml
+          echo '${{ vars.GLOBAL_SETTINGS }}' > global-settings.xml
           echo "Maven build starting"
 
           cat global-settings.xml


### PR DESCRIPTION
Because the variable is being filled by the action rather than bash, using double quotes is messing with the double quotes that exist within the text of the variable. By using single quotes, bash will handle all text literally, and the variable will still dereference, since that is happening before the script is handed to bash.