### PR TITLE
Fix: Use patchset revision to avoid collisions

### DIFF
--- a/.github/workflows/compose-jjb-verify.yaml
+++ b/.github/workflows/compose-jjb-verify.yaml
@@ -44,7 +44,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-jjb-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-jjb-${{ github.workflow }}-${{ github.event.inputs.GERRIT_PATCHSET_REVISION}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Change-id is unique to the branch. When a change is cherry-picked onto another branch with the same change-id, then first job that is queued gets cancelled. Therefore use a combination of patchset revision and change-id to avoid collision.

Error:
prepare
Canceling since a higher priority waiting request for 'required-verify-Gerrit Required
Verify-I26669f0da284d54bd6300768977369e11e42553a' exists

Issue: IT-26541