### PR TITLE
Fix: Use branch to avoid collisions

### DIFF
--- a/.github/workflows/compose-docker-release-verify.yaml
+++ b/.github/workflows/compose-docker-release-verify.yaml
@@ -59,7 +59,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-docker-release-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-docker-release-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compose-docker-verify.yaml
+++ b/.github/workflows/compose-docker-verify.yaml
@@ -65,7 +65,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-docker-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-docker-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compose-info-yaml-verify-testing.yaml
+++ b/.github/workflows/compose-info-yaml-verify-testing.yaml
@@ -53,7 +53,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-required-info-test-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-required-info-test-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compose-jjb-verify.yaml
+++ b/.github/workflows/compose-jjb-verify.yaml
@@ -44,7 +44,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-jjb-${{ github.workflow }}-${{ github.event.inputs.GERRIT_PATCHSET_REVISION}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-jjb-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -96,7 +96,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-maven-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-maven-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -65,7 +65,7 @@ env:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-packer-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-packer-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compose-repo-linting.yaml
+++ b/.github/workflows/compose-repo-linting.yaml
@@ -51,7 +51,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-repo-linting-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-repo-linting-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -69,7 +69,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: composed-ci-management-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: composed-ci-management-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/composed-gradle-nexus-iq.yaml
+++ b/.github/workflows/composed-gradle-nexus-iq.yaml
@@ -53,7 +53,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: composed-gradle-nexus-iq-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: composed-gradle-nexus-iq-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/composed-maven-nexus-iq.yaml
+++ b/.github/workflows/composed-maven-nexus-iq.yaml
@@ -79,7 +79,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: composed-maven-nexus-iq-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: composed-maven-nexus-iq-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -51,7 +51,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -48,7 +48,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-compose-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-compose-ci-management-verify.yaml
@@ -48,7 +48,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-ci-management-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-ci-management-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-compose-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-info-yaml-verify.yaml
@@ -53,7 +53,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-required-info-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-required-info-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -54,7 +54,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-rtdv3-merge-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-rtdv3-merge-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -54,7 +54,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-rtdv3-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-rtdv3-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/gerrit-compose-required-tox-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-tox-verify.yaml
@@ -81,7 +81,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: compose-tox-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: compose-tox-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gerrit-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-required-info-yaml-verify.yaml
@@ -58,7 +58,7 @@ on:
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  group: reusable-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH}}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Change-id is unique to the branch. When a change is cherry-picked onto another branch with the same change-id, then first job that is queued gets cancelled. Therefore use a combination of branch name and change-id to avoid collision.

Error:
Canceling since a higher priority waiting request for 'required-verify-Gerrit Required
Verify-I26669f0da284d54bd6300768977369e11e42553a' exists

The previous commit (0ef949323165) used patchset revision that is now updated to use Gerrit branch name.

Issue: IT-26541