### PR TITLE
Fix: Allow CLM workflows to continue on error

### DIFF
--- a/.github/workflows/composed-gradle-nexus-iq.yaml
+++ b/.github/workflows/composed-gradle-nexus-iq.yaml
@@ -91,6 +91,7 @@ jobs:
           echo "APPLICATION_ID=${{ vars.ORGANIZATION }}-${REPO_DASHED}" >> "$GITHUB_ENV"
         # yamllint enable rule:line-length
       - name: Nexus IQ Policy Evaluation
+        continue-on-error: true
         uses: sonatype-nexus-community/iq-github-action@master
         with:
           serverUrl: ${{ env.NEXUS_IQ_SERVER }}

--- a/.github/workflows/composed-maven-nexus-iq.yaml
+++ b/.github/workflows/composed-maven-nexus-iq.yaml
@@ -135,6 +135,7 @@ jobs:
           echo "APPLICATION_ID=${{ vars.ORGANIZATION }}-${REPO_DASHED}" >> "$GITHUB_ENV"
         # yamllint enable rule:line-length
       - name: Nexus IQ Policy Evaluation
+        continue-on-error: true
         uses: sonatype-nexus-community/iq-github-action@master
         with:
           serverUrl: ${{ env.NEXUS_IQ_SERVER }}


### PR DESCRIPTION
The CLM scanner reports a failure if the scan found vulnerabilities. We should allow the jobs to continue since this is the expected result.

Issue-ID: CIMAN-33