### PR TITLE
Fix: Run prebuild script given as input

### DIFF
--- a/.github/actions/tox-run-action/action.yaml
+++ b/.github/actions/tox-run-action/action.yaml
@@ -35,7 +35,7 @@ runs:
       id: pre-build
       if: ${{ hashFiles(inputs.pre-build-script) }}
       shell: bash
-      run: ${{ inputs.pre-build-script }}
+      run: ./${{ inputs.pre-build-script }}
     - name: Build package (if available)
       id: build-package
       if: ${{ hashFiles('pyproject.toml') != '' }}


### PR DESCRIPTION
We missed the actual bash run command to trigger a prebuild script if found in the inputs.