### PR TITLE
Chore: Update gerrit-review-action to v0.7

### DIFF
--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - name: Clear votes
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_USER }}
@@ -158,7 +158,7 @@ jobs:
         uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5  # v3.0.3
       - name: Set vote
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_USER }}

--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: Notify job start
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_USER }}
@@ -129,7 +129,7 @@ jobs:
         uses: technote-space/workflow-conclusion-action@v3
       - name: Report workflow conclusion
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_USER }}

--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Clear votes
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_USER }}
@@ -156,7 +156,7 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v3
       - name: Set vote
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_USER }}

--- a/.github/workflows/gerrit-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-required-info-yaml-verify.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Clear votes
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_REQUIRED_USER }}
@@ -155,7 +155,7 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v3
       - name: Set vote
         # yamllint disable-line rule:line-length
-        uses: lfit/gerrit-review-action@7c30179c3c9389545fccb0d458df59879372ae6a  # v0.6
+        uses: lfit/gerrit-review-action@26b447f499bf16876244384293ee1b8893e4fc04  # v0.7
         with:
           host: ${{ vars.GERRIT_SERVER }}
           username: ${{ vars.GERRIT_SSH_REQUIRED_USER }}


### PR DESCRIPTION
This pulls in the change to skip vote jobs on local runs.