### PR TITLE
Fix: Run a no-op bash command when there is no prebuild script

### DIFF
--- a/.github/actions/tox-run-action/action.yaml
+++ b/.github/actions/tox-run-action/action.yaml
@@ -22,7 +22,7 @@ inputs:
     description: >
       Path to optional pre-build script to trigger before verify run
     required: false
-    default: ""
+    default: "/dev/null"
 
 runs:
   using: "composite"
@@ -36,7 +36,7 @@ runs:
       id: pre-build
       if: ${{ inputs.pre-build-script != '' }}
       shell: bash
-      run: ./${{ inputs.pre-build-script }}
+      run: sh ${{ inputs.pre-build-script }}
     - name: Build package (if available)
       id: build-package
       if: ${{ hashFiles('pyproject.toml') != '' }}

--- a/.github/workflows/gerrit-compose-required-tox-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-tox-verify.yaml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         tox-env: ${{ fromJSON(inputs.TOX_ENVS) }}
     env:
-      PRE_BUILD: ""
+      PRE_BUILD: "/dev/null"
 
     steps:
       - name: Gerrit checkout


### PR DESCRIPTION
We need to run a no-operation to allow the action to continue if there is no prebuild script to run.