### PR TITLE
Allow FDio/ci-management to use newer JJB_VERSION

### DIFF
--- a/.github/workflows/gerrit-ci-management-verify.yaml
+++ b/.github/workflows/gerrit-ci-management-verify.yaml
@@ -134,6 +134,10 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           jjb_version="${JJB_VERSION:-5.1.0}"
+          version_line=$(grep '^jenkins-job-builder==' "./requirements.txt")
+          version_substring=$(echo "${version_line}" | cut -d '=' -f 3)
+          version_value=$(echo "${version_substring}" | cut -d ' ' -f 1 | cut -d '#' -f 1)
+          jjb_version="${version_value:-$jjb_version}"
           python -m pip install --upgrade pip
           pip install jenkins-job-builder=="$jjb_version"
           mkdir -p "${HOME}/.config/jenkins_jobs"


### PR DESCRIPTION
- So far only in Gerrit ci-management Verify.