### PR TITLE
Fix: gerrit-required-info-yaml-verify fetch-depth

### DIFF
--- a/.github/workflows/gerrit-required-info-yaml-verify.yaml
+++ b/.github/workflows/gerrit-required-info-yaml-verify.yaml
@@ -94,6 +94,9 @@ jobs:
           delay: "0s"
           repository: ${{ inputs.TARGET_REPO }}
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+          # We are going to compare a change to its parent,
+          # so the default fetch depth of 1 is not enough.
+          fetch-depth: "2"
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
         id: setup-python


### PR DESCRIPTION
As the point of the workflow is to verify changes to INFO.yaml, and the logic skips the check if that file is not edited, and "git diff --name-only HEAD~1" is used to detect edits, the default fetch-depth of lfit/checkout-gerrit-change-action (v0.9) of 1 is not enough.

Fix by applying check-depth 2,
also add a comment explaining why.