### PR TITLE
Fix: Install setuptools for tox jobs with py3.12

### DIFF
--- a/.github/actions/tox-run-action/action.yaml
+++ b/.github/actions/tox-run-action/action.yaml
@@ -53,6 +53,13 @@ runs:
             pip install -r requirements.txt
         fi
 
+        # python v3.12 onwards distutils module removed
+        MIN_PYTHON_VERSION=$(echo "3.11" | tr -dc '0-9')
+        INP_PYTHON_VERSION=$(echo "${{ inputs.py-version }}" | tr -dc '0-9')
+        if [[ ${INP_PYTHON_VERSION} > ${MIN_PYTHON_VERSION} ]]; then
+            pip install --upgrade pip setuptools
+        fi
+
         TOX_OPTIONS_LIST=""
         if [[ -n ${{ inputs.tox-envs }} ]]; then
             TOX_OPTIONS_LIST=" -e ${{ inputs.tox-envs }}"


### PR DESCRIPTION
The lftools license check fails the tox run with python 3.12.

The default version of the python used in the tox workflow using python 3.12. Python 3.12 does not come with a stdlib distutils module (changelog), because distutils was deprecated in 3.10 and removed in 3.12. See PEP 632 – Deprecate distutils module.

Therefore, check if python 3.12 and install distutils before the run.

Ref:
https://docs.python.org/3/whatsnew/3.12.html
https://peps.python.org/pep-0632/
Issue: RELENG-5403