### PR TITLE
CI: Enforce semantic commit messages

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,7 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Check PR for semantic commit message
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -45,3 +46,21 @@ jobs:
             Build
           validateSingleCommit: true
           validateSingleCommitMatchesPrTitle: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # checkout at the last commit
+          ref: ${{ github.event.pull_request.head.sha }}
+          # get all history
+          fetch-depth: 0
+
+      - name: Install gitlint
+        shell: bash
+        run: |
+          python -m pip install gitlint
+
+      - name: Run gitlint
+        shell: bash
+        run: |
+          gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"


### PR DESCRIPTION
The semantic commit message validator we were (and still are using) only
validates that the PR matches semantic commit message standard and if
there is a single commit in the PR, that it also matches the PR title.

Since we require that _all_ of our commits meet the standard we needed
to find another way to do this.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
