### PR TITLE
Fix: Change match string to find RTD subproject

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -159,7 +159,7 @@ jobs:
 
           declare -i cnt=0
           while [[ $project_exists == "false" ]]; do
-              if [[ "$(lftools rtd project-details "$rtdproject" | yq -r '.detail')" == "Not found." ]]; then
+              if [[ "$(lftools rtd project-details "$rtdproject" | yq -r '.detail')" == "No Project matches the given query." ]]; then
                   echo "INFO: Project not found"
                   if [[ $project_created == "false" ]]; then
                       echo "INFO: Creating project https://$rtdproject.readthedocs.io"


### PR DESCRIPTION
Current match string to find out the existence of an RTD subproject is not valid anymore. The IF condition always returns FALSE and produces undesired results.