### PR TITLE
Fix: Update actions to address node warnings

### DIFF
--- a/.github/workflows/compose-gradle-publish.yaml
+++ b/.github/workflows/compose-gradle-publish.yaml
@@ -87,7 +87,8 @@ jobs:
           python-version: "3.8"
       - name: Setup JDK
         id: setup-jdk
-        uses: actions/setup-java@v3
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ inputs.JDK_VERSION }}
           distribution: "temurin"

--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -102,12 +102,14 @@ jobs:
           version: ${{ env.PACKER_VERSION }}
       - name: Export env variables
         if: steps.changes.outputs.src == 'true'
-        uses: infovista-opensource/vars-to-env-action@1.0.0
+        # yamllint disable-line rule:line-length
+        uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
         with:
           secrets: ${{ inputs.ENV_VARS }}
       - name: Export env secrets
         if: steps.changes.outputs.src == 'true'
-        uses: infovista-opensource/vars-to-env-action@1.0.0
+        # yamllint disable-line rule:line-length
+        uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
         with:
           secrets: ${{ secrets.ENV_SECRETS }}
           include: CLOUDS_ENV_B64, CLOUDS_YAML_B64

--- a/.github/workflows/composed-autotools-sonar-cloud.yaml
+++ b/.github/workflows/composed-autotools-sonar-cloud.yaml
@@ -102,7 +102,8 @@ jobs:
           python-version: "3.8"
       - name: Setup JDK
         id: setup-jdk
-        uses: actions/setup-java@v3
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ inputs.JDK_VERSION }}
           distribution: "temurin"

--- a/.github/workflows/composed-cmake-sonar-cloud.yaml
+++ b/.github/workflows/composed-cmake-sonar-cloud.yaml
@@ -102,7 +102,8 @@ jobs:
           python-version: "3.8"
       - name: Setup JDK
         id: setup-jdk
-        uses: actions/setup-java@v3
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ inputs.JDK_VERSION }}
           distribution: "temurin"

--- a/.github/workflows/composed-generic-sonar-cloud.yaml
+++ b/.github/workflows/composed-generic-sonar-cloud.yaml
@@ -98,18 +98,21 @@ jobs:
           python-version: "3.8"
       - name: Setup JDK
         id: setup-jdk
-        uses: actions/setup-java@v3
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ inputs.JDK_VERSION }}
           distribution: "temurin"
       - name: Export env variables
         id: export-env-variables
-        uses: infovista-opensource/vars-to-env-action@1.0.0
+        # yamllint disable-line rule:line-length
+        uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
         with:
           secrets: ${{ inputs.ENV_VARS }}
       - name: Export env secrets
         id: export-env-secrets
-        uses: infovista-opensource/vars-to-env-action@1.0.0
+        # yamllint disable-line rule:line-length
+        uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
         with:
           secrets: ${{ inputs.ENV_SECRETS }}
       - name: Run pre-build-script

--- a/.github/workflows/composed-prescan-sonar-cloud.yaml
+++ b/.github/workflows/composed-prescan-sonar-cloud.yaml
@@ -101,7 +101,8 @@ jobs:
           python-version: "3.8"
       - name: Setup JDK
         id: setup-jdk
-        uses: actions/setup-java@v3
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ inputs.JDK_VERSION }}
           distribution: "temurin"


### PR DESCRIPTION
Address NodeJS 16 -> NodeJS 20 warnings.

As per GitHub post:
2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Affecting:
actions/setup-java@v3
infovista-opensource/vars-to-env-action@1.0.0
