### PR TITLE
Fix: Use the Maven pom file provided by input

### DIFF
--- a/.github/actions/maven-build-action/action.yaml
+++ b/.github/actions/maven-build-action/action.yaml
@@ -31,7 +31,7 @@ inputs:
       -Dmaven.repo.local=/tmp/r -Dorg.ops4j.pax.url.mvn.localRepository=/tmp/r
       -DaltDeploymentRepository=staging::default::file:"${GITHUB_WORKSPACE}"/m2repo
   mvn-pom-file:
-    description: "Directory with pom.xml"
+    description: "Path to pom.xml file."
     required: false
     default: "pom.xml"
   mvn-profiles:
@@ -92,6 +92,7 @@ runs:
         cat global-settings.xml
 
         mvn ${{ inputs.mvn-phases }} \
+            -f ${{ inputs.mvn-pom-file }} \
             -e \
             --global-settings global-settings.xml \
             -DaltDeploymentRepository=staging::default::file:"${GITHUB_WORKSPACE}"/m2repo \

--- a/.github/workflows/compose-maven-merge.yaml
+++ b/.github/workflows/compose-maven-merge.yaml
@@ -48,7 +48,7 @@ on:
         # yamllint enable rule:line-length
         type: string
       MVN_POM_FILE:
-        description: "Directory with pom.xml"
+        description: "Path to pom.xml file."
         required: false
         default: "pom.xml"
         type: string

--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -75,7 +75,7 @@ on:
         # yamllint enable rule:line-length
         type: string
       MVN_POM_FILE:
-        description: "Directory with pom.xml"
+        description: "Path to pom.xml file."
         required: false
         default: "pom.xml"
         type: string


### PR DESCRIPTION
While there is an input parameter for setting a custom pom.xml file there is no code to actually utilize it. This change fixes that issue and enables the use of alternative pom.xml file path. Also fix the description of parameter to state that its the path to the file and not directory.