### PR TITLE
Test: Create minimal unit test for Maven jobs

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -84,6 +84,11 @@ on:
         required: false
         default: ""
         type: string
+      MVN_GLOBAL_SETTINGS:
+        description: "Maven global settings configuration."
+        required: false
+        default: ${{ vars.GLOBAL_SETTINGS }}
+        type: string
       ENV_VARS:
         # yamllint disable-line rule:line-length
         description: "Pass GitHub variables to be exported as environment variables via `toJSON(vars)` or specific variables encoded in JSON format"
@@ -128,4 +133,4 @@ jobs:
           mvn-profiles: ${{ inputs.MVN_PROFILES }}
           env-vars: ${{ inputs.ENV_VARS }}
           env-secrets: ${{ inputs.ENV_SECRETS }}
-          global-settings: ${{ vars.GLOBAL_SETTINGS }}
+          global-settings: ${{ inputs.MVN_GLOBAL_SETTINGS }}

--- a/.github/workflows/zzci-test-verify-maven.yaml
+++ b/.github/workflows/zzci-test-verify-maven.yaml
@@ -1,0 +1,17 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Linux Foundation
+
+name: Verify Maven Workflows
+
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+
+jobs:
+  test-maven-verify:
+    uses: ./.github/workflows/compose-maven-verify.yaml
+    with:
+      GERRIT_BRANCH: ${{ github.ref }}
+      GERRIT_CHANGE_ID: Ic8aaa0728a43936cd4c6e1ed590e01ba8f0fbf5b
+      MVN_POM_FILE: test/maven-project/pom.xml
+      MVN_GLOBAL_SETTINGS: "<settings/>"

--- a/test/maven-project/pom.xml
+++ b/test/maven-project/pom.xml
@@ -1,0 +1,11 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2024 The Linux Foundation
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.linuxfoundation.test</groupId>
+  <artifactId>maven-test-app</artifactId>
+  <version>1</version>
+</project>


### PR DESCRIPTION
This change creates a minimal pom.xml for unit testing of Maven jobs and creates a test job for the Maven Verify workflow. The intent here is to create a small unit test that can quickly validate Maven workflows and catch potential issues that maybe missed by a linter.
