### PR TITLE
Fix: Correct var name, use secrets rather than env

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -125,7 +125,7 @@ jobs:
           echo "::add-mask::$COMMAND_RESUME_TOKEN"
           # Stop command workflow processing
           echo "::stop-commands::$COMMAND_RESUME_TOKEN"
-          clouds_env_b64="${{ env.CLOUDS_ENV_B64 }}"
+          clouds_env_b64="${{ secrets.CLOUDS_ENV_B64 }}"
           echo "${clouds_env_b64}" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
           # Resume workflow command processing
           echo "::$COMMAND_RESUME_TOKEN::"
@@ -143,7 +143,7 @@ jobs:
           echo "::add-mask::$COMMAND_RESUME_TOKEN"
           # Stop command workflow processing
           echo "::stop-commands::$COMMAND_RESUME_TOKEN"
-          clouds_yaml_b64="${{ env.CLOUDS_YAML_B64 }}"
+          clouds_yaml_b64="${{ secrets.CLOUDS_YAML_B64 }}"
           echo "${clouds_yaml_b64}" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
           # Resume workflow command processing
           echo "::$COMMAND_RESUME_TOKEN::"

--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -147,7 +147,7 @@ jobs:
     secrets:
       ENV_SECRETS: ${{ toJSON(secrets) }}
       CLOUDS_ENV_B64: ${{ secrets.CLOUDS_ENV_B64 }}
-      CLOUDS_YAML_B64: ${{ secrets.CLOUDS_ENV_B64 }}
+      CLOUDS_YAML_B64: ${{ secrets.CLOUDS_YAML_B64 }}
 
   vote:
     if: ${{ always() }}


### PR DESCRIPTION
The variable name for CLOUDS_YAML_B64 was incorrect in the composed
ci-man verify workflow.

In compose-packer-verify, we are referencing the CLOUD secrets from
the env. While these may be available in the env after the "Export
env secrets" step, it's still safer to use the secrets context.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>
