### PR TITLE
Fix: Packer secrets back to env

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -125,7 +125,7 @@ jobs:
           echo "::add-mask::$COMMAND_RESUME_TOKEN"
           # Stop command workflow processing
           echo "::stop-commands::$COMMAND_RESUME_TOKEN"
-          clouds_env_b64="${{ secrets.CLOUDS_ENV_B64 }}"
+          clouds_env_b64="${{ env.CLOUDS_ENV_B64 }}"
           echo "${clouds_env_b64}" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
           # Resume workflow command processing
           echo "::$COMMAND_RESUME_TOKEN::"
@@ -143,7 +143,7 @@ jobs:
           echo "::add-mask::$COMMAND_RESUME_TOKEN"
           # Stop command workflow processing
           echo "::stop-commands::$COMMAND_RESUME_TOKEN"
-          clouds_yaml_b64="${{ secrets.CLOUDS_YAML_B64 }}"
+          clouds_yaml_b64="${{ env.CLOUDS_YAML_B64 }}"
           echo "${clouds_yaml_b64}" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
           # Resume workflow command processing
           echo "::$COMMAND_RESUME_TOKEN::"


### PR DESCRIPTION
There is an issue with passing secrets through workflows that we haven't figured out yet. This was based on @askb's own work, as he asked and answered here:
https://github.com/orgs/community/discussions/65057