### PR TITLE
Fix: Securely mask secrets in Reusable Workflows

### DIFF
--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -55,12 +55,6 @@ on:
         # yamllint disable-line rule:line-length
         description: "Pass GitHub secrets to be exported as environment variables via `toJSON(secrets)` or specific secrets encoded in JSON format"
         required: false
-      CLOUDS_ENV_B64:
-        description: "Packer cloud environment credentials"
-        required: true
-      CLOUDS_YAML_B64:
-        description: "Openstack cloud environment credentials"
-        required: true
 
 env:
   OS_CLOUD: "vex"
@@ -74,6 +68,8 @@ concurrency:
 jobs:
   packer-validator:
     runs-on: ubuntu-latest
+    env:
+      ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
     steps:
       - name: Gerrit Checkout
         # yamllint disable-line rule:line-length
@@ -106,29 +102,25 @@ jobs:
         uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
         with:
           secrets: ${{ inputs.ENV_VARS }}
-      - name: Export env secrets
-        if: steps.changes.outputs.src == 'true'
-        # yamllint disable-line rule:line-length
-        uses: infovista-opensource/vars-to-env-action@3d3e7c8ae1e9e5fcd9ce83e56ab85a6a135d2ffa # v2.0.0
-        with:
-          secrets: ${{ secrets.ENV_SECRETS }}
-          include: CLOUDS_ENV_B64, CLOUDS_YAML_B64
+      - name: Double base64 decode credentials as store as environment variables
+        run: |
+          for kval in $ENV_SECRETS; do
+              # extract the key name
+              key="${kval%%=*}"
+              # extract the value in b64 format
+              encoded_val="${kval#*=}"
+              # mask to encoded value
+              echo ::add-mask::"$encoded_val"
+              printf '%s<<EOF\n%s\nEOF\n' "$key" "$encoded_val" >> "$GITHUB_ENV"
+          done
       - name: Create cloud-env file required for packer
         id: create-cloud-env-file
         if: steps.changes.outputs.src == 'true'
         shell: /usr/bin/bash {0}
         # yamllint disable rule:line-length
         run: |
-          # Generate a unique resume token for this workflow run
-          COMMAND_RESUME_TOKEN=$(echo -n ${{ github.token }} | sha256sum | head -c 64)
-          # Mask the resume token's value in the logs
-          echo "::add-mask::$COMMAND_RESUME_TOKEN"
-          # Stop command workflow processing
-          echo "::stop-commands::$COMMAND_RESUME_TOKEN"
-          clouds_env_b64="${{ env.CLOUDS_ENV_B64 }}"
-          echo "${clouds_env_b64}" | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
-          # Resume workflow command processing
-          echo "::$COMMAND_RESUME_TOKEN::"
+          clouds_env_b64="$CLOUDS_ENV_2XB64"
+          echo "${clouds_env_b64}" | base64 --decode | base64 --decode > "${GITHUB_WORKSPACE}/cloud-env.pkrvars.hcl"
         # yamllint enable rule:line-length
       - name: Create cloud.yaml file for openstack client
         id: create-cloud-yaml-file
@@ -137,16 +129,8 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           mkdir -p "$HOME/.config/openstack"
-          # Generate a unique resume token for this workflow run
-          COMMAND_RESUME_TOKEN=$(echo -n ${{ github.token }} | sha256sum | head -c 64)
-          # Mask the resume token's value in the logs
-          echo "::add-mask::$COMMAND_RESUME_TOKEN"
-          # Stop command workflow processing
-          echo "::stop-commands::$COMMAND_RESUME_TOKEN"
-          clouds_yaml_b64="${{ env.CLOUDS_YAML_B64 }}"
-          echo "${clouds_yaml_b64}" | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
-          # Resume workflow command processing
-          echo "::$COMMAND_RESUME_TOKEN::"
+          clouds_yaml_b64="$CLOUDS_YAML_2XB64"
+          echo "${clouds_yaml_b64}" | base64 --decode | base64 --decode > "$HOME/.config/openstack/clouds.yaml"
         # yamllint enable rule:line-length
       - name: Setup Python
         if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/composed-ci-management-verify.yaml
+++ b/.github/workflows/composed-ci-management-verify.yaml
@@ -63,10 +63,10 @@ on:
       GERRIT_SSH_PRIVKEY:
         description: "SSH Key for the authorized user account"
         required: true
-      CLOUDS_ENV_B64:
+      CLOUDS_ENV_2XB64:
         description: "Packer cloud environment credentials"
         required: true
-      CLOUDS_YAML_B64:
+      CLOUDS_YAML_2XB64:
         description: "Openstack cloud environment credentials"
         required: true
 
@@ -145,9 +145,9 @@ jobs:
       GERRIT_REFSPEC: ${{ inputs.GERRIT_REFSPEC }}
       ENV_VARS: ${{ toJSON(vars) }}
     secrets:
-      ENV_SECRETS: ${{ toJSON(secrets) }}
-      CLOUDS_ENV_B64: ${{ secrets.CLOUDS_ENV_B64 }}
-      CLOUDS_YAML_B64: ${{ secrets.CLOUDS_YAML_B64 }}
+      ENV_SECRETS: |
+        CLOUDS_ENV_2XB64: ${{ secrets.CLOUDS_ENV_2XB64 }}
+        CLOUDS_YAML_2XB64: ${{ secrets.CLOUDS_YAML_2XB64 }}
 
   vote:
     if: ${{ always() }}


### PR DESCRIPTION
Problem:

This commit addresses the issue of secret exposure when passing secrets between reusable workflows in GitHub Actions. Automatic secret masking within reusable workflows is lost due to secret inheritance limitations. Additionally, multiline secrets and special characters pose challenges [1.] is undefined with Github actions.

Proposed Solution:

To redact and mask secrets from console logs, I propose the two-step Base64 encoding approach inspired by [2.]:

1. Double Base64 Encoding: Before storing secrets in the organization or repository secret store, encode them twice using the base64 command. This prevents secret exposure when GitHub Actions outputs them.

example:
cat clouds.yaml | base64 -w0 | base64 -w0 > clouds-2xb64.yaml cat clouds-env.pkrvars.hcl | base64 -w0 | base64 -w0 > \
	clouds-2xb64.yaml

2. Pass Encoded Values and Decode in Reusable Workflows: Pass the encoded values as secret inputs to reusable workflows. Inside the workflows, decode them twice before masking to ensure they remain masked throughout the logs and usable in subsequent steps.

Limitation:

Rerunning jobs in debug mode might reveal secrets in the workflow logs. However, only authorized users with "owner" permissions can trigger debug re-runs, mitigating the overall risk.

Benefits:

+ Consistent secret masking within reusable workflows.
+ Secure handling of multiline secrets and special characters.
+ Reduced risk of accidental secret exposure in workflow logs.

Note: The secrets have been renamed as and encoded twice and saved on the Github secret store.

References:
[1.] https://github.com/orgs/community/discussions/65057 [2.] https://github.com/orgs/community/discussions/26671