### PR TITLE
Feat: New composite action to inject an issue-id into commit msg

### DIFF
--- a/.github/actions/git-commit-message-action/README.md
+++ b/.github/actions/git-commit-message-action/README.md
@@ -1,0 +1,50 @@
+# 💬 GIT Commit Message
+
+Action that returns the last/current commit message to a calling GitHub
+action/workflow.
+
+## git-commit-message-action
+
+## Usage Example
+
+Sets the account name/email used for Git operations inside other
+actions/workflows.
+
+```yaml
+- name: "Configure GIT user for commit"
+  uses: lfit/releng-reusable-workflows/.github/actions/git-configure-action@main
+  with:
+      commit-user-name: "John Doe"
+      commit-user-email: "john.doe@somedomain.org"
+```
+
+## Inputs
+
+This action takes/requires no explicit inputs.
+
+## Outputs
+
+| Variable Name  | Description                                        |
+| -------------- | -------------------------------------------------- |
+| COMMIT_MESSAGE | String of the last/current Git commit message body |
+
+The action provides summary step output when invoked, displaying the returned
+commit message body. It also outputs the string value explicitly, and as an
+environment export to the calling action/workflow.
+
+## Requirements/Dependencies
+
+Perform a repository checkout step before using the action.
+
+### Command used
+
+The command used to capture the message is:
+
+```console
+git show -s --format='%B'
+```
+
+<!--
+[comment]: # SPDX-License-Identifier: Apache-2.0
+[comment]: # SPDX-FileCopyrightText: 2024 The Linux Foundation
+-->

--- a/.github/actions/git-commit-message-action/action.yaml
+++ b/.github/actions/git-commit-message-action/action.yaml
@@ -1,0 +1,30 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Linux Foundation
+
+name: "💬 GIT Commit Message"
+
+outputs:
+  COMMIT_MESSAGE:
+    description: "GIT commit message"
+    value: ${{ steps.return.outputs.commit_message }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Retrieve GIT commit message"
+      id: return
+      shell: bash
+      run: |
+        # Retrieve GIT commit message
+        COMMIT_MESSAGE=$(git show -s --format='%B')
+        if [ -z "$COMMIT_MESSAGE" ]; then
+          echo "GIT Commit Message string was empty ❌" >> "$GITHUB_STEP_SUMMARY"
+          echo "GIT Commit Message string was empty ❌"; exit 1
+        fi
+        echo "COMMIT_MESSAGE<<EOF"$'\n'"$COMMIT_MESSAGE"$'\n'EOF >> \
+          "$GITHUB_ENV"
+        echo "COMMIT_MESSAGE<<EOF"$'\n'"$COMMIT_MESSAGE"$'\n'EOF >> \
+          "$GITHUB_OUTPUT"
+        echo "GIT Commit Message 💬"
+        echo "$COMMIT_MESSAGE"

--- a/.github/actions/git-configure-action/README.md
+++ b/.github/actions/git-configure-action/README.md
@@ -1,0 +1,44 @@
+# 🛠️ Configure GIT User
+
+Action to configure the Git username/email inside a GitHub action/workflow
+
+## git-configure-action
+
+## Usage Example
+
+```yaml
+- name: "Configure GIT user for commit"
+  uses: lfit/releng-reusable-workflows/.github/actions/git-configure-action@main
+  with:
+      commit-user-name: "John Doe"
+      commit-user-email: "john.doe@somedomain.org"
+```
+
+## Inputs
+
+By default, the action will configure Git operations to use the Github actions
+automation/bot account.
+
+<!-- markdownlint-disable MD013 -->
+
+| Variable Name     | Required | Default Value                                         | Description        |
+| ----------------- | -------- | ----------------------------------------------------- | ------------------ |
+| COMMIT_USER_NAME  | False    | github-actions[bot]                                   | User name          |
+| COMMIT_USER_EMAIL | False    | 41898282+github-actions[bot]@users.noreply.github.com | User email address |
+
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+The action has no outputs, but does provide summary step information when
+invoked.
+
+## Requirements/Dependencies
+
+The git command-line tool must be available in the environment for the action
+to succeed.
+
+<!--
+[comment]: # SPDX-License-Identifier: Apache-2.0
+[comment]: # SPDX-FileCopyrightText: 2024 The Linux Foundation
+-->

--- a/.github/actions/git-configure-action/action.yaml
+++ b/.github/actions/git-configure-action/action.yaml
@@ -1,0 +1,36 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Linux Foundation
+
+name: "🛠️ Configure GIT User"
+
+inputs:
+  COMMIT_USER_NAME:
+    description: "User used to perform the commit"
+    type: string
+    required: false
+    default: "github-actions[bot]"
+  COMMIT_USER_EMAIL:
+    description: "User used to perform the commit"
+    type: string
+    required: false
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Configure GIT user"
+      id: configure
+      shell: bash
+      run: |
+        # Configure GIT user
+        git config user.name "${{ inputs.COMMIT_USER_NAME }}"
+        git config user.email "${{ inputs.COMMIT_USER_EMAIL }}"
+        echo "🛠️ Configure GIT User"
+        echo "User name: ${{ inputs.COMMIT_USER_NAME }}"
+        echo "User email: ${{ inputs.COMMIT_USER_EMAIL }}"
+        echo "### 🛠️ Configure GIT User" >> "$GITHUB_STEP_SUMMARY"
+        echo "User name: ${{ inputs.COMMIT_USER_NAME }}" >> \
+          "$GITHUB_STEP_SUMMARY"
+        echo "User email: ${{ inputs.COMMIT_USER_EMAIL }}" >> \
+          "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/inject-issue-id-action/README.md
+++ b/.github/actions/inject-issue-id-action/README.md
@@ -1,0 +1,60 @@
+# 🎟️ Add JIRA ticket/issue to commit message body
+
+Action to add a JIRA ticket/Issue-ID line to the body of a commit message.
+
+## inject-issue-id-action
+
+## Usage Example
+
+Pass a JSON key/value lookup table to the action, either directly as a string,
+or by passing in the contents of a variable (set either at the repository or
+organisation level).
+
+```yaml
+- name: "Check/Add commit message JIRA ticket"
+  uses: ModeSevenIndustrialSolutions/issue-id/.github/actions/inject-issue-id-action@main
+  with:
+      issue_id_lookup_json: ${{ vars.ISSUE_ID_LOOKUP_JSON }}
+```
+
+In the example above, the repository passes in the JSON data contained in
+a variable configured called ISSUE_ID_LOOKUP_JSON.
+
+Set/define this for the repository under:
+
+GitHub Repository -> Settings -> Secrets and variables -> Actions -> Variables
+
+## Inputs
+
+The action does not have any default values and both input parameters are mandatory.
+
+<!-- markdownlint-disable MD013 -->
+
+| Variable Name        | Required | Default | Description                         |
+| -------------------- | -------- | ------- | ----------------------------------- |
+| ISSUE_ID_LOOKUP_JSON | True     | N/A     | JSON array of key/value pairs       |
+| INJECT               | False    | True    | When set false, checks for presence |
+
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Variable Name | Description                                   |
+| ------------- | --------------------------------------------- |
+| PRESENT       | Set true when ticket string found or injected |
+
+## Limitations
+
+This action uses ${{ github.actor }} as the key to lookup, but also reports
+the ${{ github.actor_id }}, which is a GitHub facsimile to the UNIX concept
+of a UID value.
+
+## Future Enhancements
+
+It may be desirable to use other GitHub parameters as keys in the JSON
+value/lookup.
+
+<!--
+[comment]: # SPDX-License-Identifier: Apache-2.0
+[comment]: # SPDX-FileCopyrightText: 2024 The Linux Foundation
+-->

--- a/.github/actions/inject-issue-id-action/action.yaml
+++ b/.github/actions/inject-issue-id-action/action.yaml
@@ -1,0 +1,98 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Linux Foundation
+
+name: "🎟️ Add JIRA ticket to commit message"
+
+inputs:
+  ISSUE_ID_LOOKUP_JSON:
+    description: "JSON mapping users to JIRA tickets"
+    type: string
+    required: true
+  INJECT:
+    # When injection is enabled and no issue found...
+    # String will be added, output variable set true
+    description: "Whether to inject an issue-id if NOT found"
+    type: boolean
+    required: false
+    default: true
+
+outputs:
+  PRESENT:
+    description: "Whether the required ticket string is present"
+    value: ${{ steps.status.outputs.present }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: "Get GIT commit message body"
+      id: commit-message
+      # yamllint disable rule:line-length
+      uses: lfit/releng-reusable-workflows/.github/actions/git-commit-message-action@main
+
+    - name: "Check commit message for ticket/string"
+      shell: bash
+      run: |
+        # Check commit message for ticket/string
+        echo "# Checking Commit Message for JIRA Ticket" >> "$GITHUB_STEP_SUMMARY"
+
+        COMMIT_MESSAGE="${{ env.COMMIT_MESSAGE }}"
+        if [ -z "$COMMIT_MESSAGE" ]; then
+          echo "Commit message body was empty/unpopulated ❌"; exit 1
+        fi
+        if [[ "$COMMIT_MESSAGE" =~ "Issue-ID: " ]]; then
+          echo "Ticket string found in the pull request ✅" >> "$GITHUB_STEP_SUMMARY"
+          echo "Ticket string found in the pull request ✅"
+          echo "PRESENT=true" >> "$GITHUB_ENV"
+        else
+          echo "Ticket string NOT found in the pull request ❌" >> "$GITHUB_STEP_SUMMARY"
+          echo "Ticket string NOT found in the pull request ❌"
+          echo "PRESENT=false" >> "$GITHUB_ENV"
+        fi
+
+    - name: "Set key to use for JSON lookup"
+      if: env.PRESENT == 'false' && inputs.INJECT == 'true'
+      shell: bash
+      run: |
+        # Set key to use for JSON lookup
+        ACTOR="${{ github.actor }}"
+        ACTOR_ID="${{ github.actor_id }}"
+        echo "Using GitHub actor as lookup key: $ACTOR [$ACTOR_ID] 🔑"
+        echo "key=$ACTOR" >> "$GITHUB_ENV"
+
+    - name: "Get ticket from JSON lookup table"
+      if: env.PRESENT == 'false' && inputs.INJECT == 'true'
+      uses: lfit/releng-reusable-workflows/.github/actions/json-key-value-lookup-action@main
+      with:
+        json: ${{ inputs.issue_id_lookup_json }}
+        key: ${{ env.key }}
+
+    - name: "Configure GIT user for commit"
+      if: env.PRESENT == 'false' && inputs.INJECT == 'true'
+      uses: lfit/releng-reusable-workflows/.github/actions/git-configure-action@main
+
+    - name: "Adding JIRA ticket reference to commit message"
+      id: inject
+      # yamllint disable-line rule:line-length
+      if: env.PRESENT == 'false' && inputs.INJECT == 'true' && (github.event.pull_request.head.ref != github.ref_name) && (github.event.pull_request.head.ref != github.event.pull_request.base.ref)
+      shell: bash
+      run: |
+        # Adding JIRA ticket reference to commit message
+        git commit --amend -m "${{ env.COMMIT_MESSAGE }}" -m "Issue-ID: ${{ env.value }}" --no-verify --no-edit
+        echo "Performing force push on pull request ⚠️"
+        git push --force
+        echo "present=true" >> "$GITHUB_ENV"
+        echo "Added JIRA ticket reference: ${{ env.value }} 🎟️"
+        echo "### 🎟️ Added JIRA ticket reference: ${{ env.value }}" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: "Set status/outputs"
+      id: status
+      shell: bash
+      run: |
+        # Set status/outputs
+        echo "present=${{ env.present }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/json-key-value-lookup-action/README.md
+++ b/.github/actions/json-key-value-lookup-action/README.md
@@ -1,0 +1,75 @@
+# 🔑 JSON Variable Key/Value Lookup
+
+Action to perform a lookup from a JSON string containing a simple array of
+key/value pairs.
+
+## json-key-value-lookup-action
+
+## Usage Example
+
+Pass a JSON string as an input to the action, along with the key to lookup.
+The action will return the corresponding value, using JQ to pass the JSON.
+
+```yaml
+- name: "Get ticket reference from JSON lookup table"
+  uses: lfit/releng-reusable-workflows/.github/actions/json-key-value-lookup-action@main
+  with:
+      json: ${{ inputs.issue_id_lookup_json }}
+      key: ${{ env.key }}
+```
+
+## Example JSON Variable
+
+Provide JSON as an array containing simple key/value pairs, as shown below.
+
+```json
+[
+    { "key": "dependabot[bot]", "value": "CIMAN-33" },
+    { "key": "John Doe", "value": "CIMAN-1000" }
+]
+```
+
+In the example above, the repository has a variable configured called: ISSUE_ID_LOOKUP_JSON
+
+Set/define this under:
+
+[ Github Repository ] -> Settings -> Secrets and variables -> Actions -> Variables
+
+## Inputs
+
+The action does not have any default values and both input parameters are mandatory.
+
+| Variable Name | Required | Description                                |
+| ------------- | -------- | ------------------------------------------ |
+| JSON          | True     | JSON dictionary containing key/value pairs |
+| KEY           | True     | Key to use to extract corresponding value  |
+| DEFAULT       | False    | Default value in the event lookup fails    |
+
+### Note 🗒️
+
+In the event of a lookup failure, the action will exit with an error. Specifying
+a default value will prevent this failure from taking place, allowing the calling
+action/workflow to take alternative action, preventing the failure from
+stopping the entire pipeline.
+
+## Outputs
+
+| Variable Name | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| VALUE         | The value corresponding to the key (provided as input) |
+
+## Requirements/Dependencies
+
+Ensure validated JSON (in the format specified above) is in the variable.
+The action performs validation before the lookup and will otherwise throw
+an error.
+
+If the key is not represented in the lookup table, the action will exit with an
+error. This behaviour will result in the calling action/workflow failing.
+Prevent this by setting a default return value, allowing upstream code to take
+alternative paths.
+
+<!--
+[comment]: # SPDX-License-Identifier: Apache-2.0
+[comment]: # SPDX-FileCopyrightText: 2024 The Linux Foundation
+-->

--- a/.github/actions/json-key-value-lookup-action/action.yaml
+++ b/.github/actions/json-key-value-lookup-action/action.yaml
@@ -1,0 +1,79 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Linux Foundation
+
+name: "🔑 JSON Variable Key/Value Lookup"
+
+inputs:
+  JSON:
+    description: "The JSON key/value lookup table"
+    type: string
+    required: true
+  KEY:
+    description: "The JSON key requiring lookup"
+    type: string
+    required: true
+  DEFAULT:
+    # Can be used to prevent exit/error if lookup fails
+    description: "Default value to return if lookup fails"
+    type: string
+    required: false
+
+outputs:
+  VALUE:
+    description: "The value associated with the supplied key"
+    value: ${{ steps.lookup.outputs.value }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "JSON Variable Key/Value Lookup"
+      id: lookup
+      shell: bash
+      run: |
+        # JSON Variable Key/Value Lookup
+
+        echo "### 🔑 JSON Variable Key/Value Lookup" >> "$GITHUB_STEP_SUMMARY"
+
+        KEY="${{ inputs.key }}"
+        DEFAULT="${{ inputs.default }}"
+
+        # Validate that input variables are populated
+        if [ -z "${{ inputs.json }}" ]; then
+          echo "Error: variable/JSON string was NOT passed as input ❌"
+          exit 1
+        elif [ -z "$KEY" ]; then
+          echo "Error: required lookup key was NOT passed as input ❌"
+          exit 1
+        fi
+
+        # Ensure JSON parser/binary is available
+        JQ=$(which jq || true)
+        if [ ! -x "$JQ" ]; then
+          echo "Error: jq command was NOT found in the PATH ❌"; exit 1
+        fi
+
+        # Check that string parses as valid JSON
+        if (jq -re '""' <<< '${{ inputs.json }}' 2>&1); then
+          echo "JSON parsing successful ✅"
+        else
+          echo "Error: jq command was NOT able to parse JSON ❌"; exit 1
+        fi
+
+        echo "Key to lookup: $KEY 🔑"
+
+        VALUE=$(echo '${{ inputs.JSON }}' | \
+          jq -r --arg KEY "$KEY" '.[] | select(.key==$KEY) | .value')
+        if [ -z "$VALUE" ] && [ -z "$DEFAULT" ]; then
+          # If no default return value provided, throw a fatal error
+          echo "Key/value lookup failed ❌"; exit 1
+        elif [ -z "$VALUE" ]; then
+          echo "Key/value lookup failed ⚠️"
+          VALUE="$DEFAULT"
+        fi
+
+        echo "Returning value: $VALUE 💬"
+        echo "value=$VALUE" >> "$GITHUB_ENV"
+        echo "value=$VALUE" >> "$GITHUB_OUTPUT"
+        echo "Key to lookup: ${{ inputs.key }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "Value returned: $VALUE" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Also provides micro-actions for perfoming a key/value lookup in a JSON variable. Another micro-action to fetch the message body, and one more to configure GIT operations in GitHub, which conveniently defaults to the GHA automation/BOT user account.

Tested here:
https://github.com/ModeSevenIndustrialSolutions/test-issue-id/actions/runs/12011503337
https://github.com/ModeSevenIndustrialSolutions/test-issue-id/actions/runs/12011503337/job/33480638748