### PR TITLE
Chore: Pin to commit SHAs, update workflow label

### DIFF
--- a/.github/workflows/reuse-verify-github-actions.yaml
+++ b/.github/workflows/reuse-verify-github-actions.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
 # Verifies action/workflow calls are pinned to SHA commit values
-name: 📌 Audit GitHub Actions
+name: 📌 [R] Audit GitHub Actions
 
 # yamllint disable-line rule:truthy
 on:
@@ -20,4 +20,4 @@ jobs:
     steps:
       - name: Check Pinned Versions
         # yamllint disable-line rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/actions/pinned-versions-action@main
+        uses: lfit/releng-reusable-workflows/.github/actions/pinned-versions-action@fd9bc3881956c2645d4da312079580d331f562ed # v0.2.2

--- a/.github/workflows/verify-github-actions.yaml
+++ b/.github/workflows/verify-github-actions.yaml
@@ -24,6 +24,6 @@ jobs:
   verify:
     name: Verify
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-verify-github-actions.yaml@main
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-verify-github-actions.yaml@fd9bc3881956c2645d4da312079580d331f562ed # v0.2.2
     permissions:
       contents: read


### PR DESCRIPTION
Update local repository verification job (that checks actions/workflows for SHA commit values) to comply with reusable workflow naming convention. Also, pins version used to commit SHA values.