### PR TITLE
Fix: Set java-version for s4u/setup-maven-action

### DIFF
--- a/.github/actions/maven-build-action/action.yaml
+++ b/.github/actions/maven-build-action/action.yaml
@@ -71,6 +71,7 @@ runs:
       # yamllint disable-line rule:line-length
       uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
       with:
+        java-version: ${{ inputs.jdk-version }}
         maven-version: ${{ inputs.mvn-version }}
     - name: Export env variables
       id: export-env-variables


### PR DESCRIPTION
When the java-version input is unset, s4u/setup-maven-action defaults to JDK "17" and results in maven verify job failures. ODL requires more recent LTS release of JDK 21.