### PR TITLE
CI: Disable linting on commit message lines

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -31,3 +31,7 @@ contrib=contrib-title-conventional-commits,contrib-body-requires-signed-off-by
 
 [contrib-title-conventional-commits]
 types=Fix,Feat,Chore,Docs,Style,Refactor,Perf,Test,Revert,CI,Build
+
+# Disable linting on lines that have URLs on them
+[ignore-body-lines]
+regex=(.*)https?://(.*)


### PR DESCRIPTION
Lines with URLs in them are being flagged by the gitlint tool as being
too long. As this is unavoidable in some cases, we will disable the
linting on these lines.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
