### PR TITLE
CI: Pin GitHub Actions in use

### DIFF
--- a/.github/workflows/compose-docker-verify.yaml
+++ b/.github/workflows/compose-docker-verify.yaml
@@ -129,7 +129,8 @@ jobs:
         # yamllint enable rule:line-length
       - name: Docker build and push
         if: env.DOCKER_IMAGE_TAG != ''
-        uses: docker/build-push-action@v6
+        # yamllint disable-line rule:line-length
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
           build-args: ${{ inputs.DOCKER_BUILD_ARGS }}
           tags: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/compose-maven-merge.yaml
+++ b/.github/workflows/compose-maven-merge.yaml
@@ -93,7 +93,7 @@ jobs:
   maven-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           submodules: "true"
@@ -104,7 +104,7 @@ jobs:
           python-version: "3.10"
       - name: Run Maven
         # yamllint disable-line rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@main
+        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@46fce72e65b1838c2bfbc6ba0ad29cdd9f229303 # 2025-02-10
         with:
           jdk-version: ${{ inputs.JDK_VERSION }}
           mvn-version: ${{ inputs.MVN_VERSION }}
@@ -115,7 +115,8 @@ jobs:
           mvn-profiles: ${{ inputs.MVN_PROFILES }}
           global-settings: ${{ vars.GLOBAL_SETTINGS }}
       - name: Sign artifacts
-        uses: lfit/sigul-sign@v1
+        # yamllint disable-line rule:line-length
+        uses: lfit/sigul-sign-action@39307c0b992e7c92ca4d2558409da96c0cc2bc15 # v1.0.0
         # Though inputs.SIGUL_SIGN is defined as a boolean, there is an issue
         # with inputs always being strings. Therefore we will only run if the
         # input is defined as string 'true.'
@@ -132,7 +133,8 @@ jobs:
           sigul-pass: ${{ secrets.SIGUL_PASS }}
           sigul-pki: ${{ secrets.SIGUL_PKI }}
       - name: Push build
-        uses: actions/upload-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: release-artifact
           path: ${{ inputs.ARTIFACT_DIR }}
@@ -143,12 +145,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull build
-        uses: actions/download-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: release-artifact
           path: "${{ inputs.ARTIFACT_DIR }}"
       - name: Publish to Nexus
-        uses: lfit/nexus-upload-action@0.1.8
+        # yamllint disable-line rule:line-length
+        uses: lfit/nexus-upload-action@977af1a1db8719876f12ed6d83fa453fcabb2f7a # v0.1.8
         with:
           nexus_server: ${{ vars.NEXUS_SERVER }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -162,7 +166,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull build
-        uses: actions/download-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: release-artifact
           path: "${{ inputs.ARTIFACT_DIR }}"
@@ -184,12 +189,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull build
-        uses: actions/download-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: release-artifact
           path: "${{ inputs.ARTIFACT_DIR }}"
       - name: Publish to Maven Central
-        uses: lfit/nexus-upload-action@0.1.8
+        # yamllint disable-line rule:line-length
+        uses: lfit/nexus-upload-action@977af1a1db8719876f12ed6d83fa453fcabb2f7a # v0.1.8
         with:
           nexus_server: ${{ vars.CENTRAL_SERVER }}
           nexus_username: ${{ secrets.CENTRAL_USERNAME }}

--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -111,7 +111,7 @@ jobs:
   maven-verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           submodules: "true"
@@ -122,7 +122,7 @@ jobs:
           python-version: "3.8"
       - name: Run Maven
         # yamllint disable-line rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@main
+        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@46fce72e65b1838c2bfbc6ba0ad29cdd9f229303 # 2025-02-10
         with:
           jdk-version: ${{ inputs.JDK_VERSION }}
           mvn-version: ${{ inputs.MVN_VERSION }}

--- a/.github/workflows/compose-packer-verify.yaml
+++ b/.github/workflows/compose-packer-verify.yaml
@@ -92,7 +92,8 @@ jobs:
               - 'packer/**'
       - name: Setup packer
         if: steps.changes.outputs.src == 'true'
-        uses: hashicorp/setup-packer@main
+        # yamllint disable-line rule:line-length
+        uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3.1.0
         id: setup
         with:
           version: ${{ env.PACKER_VERSION }}

--- a/.github/workflows/composed-maven-nexus-iq.yaml
+++ b/.github/workflows/composed-maven-nexus-iq.yaml
@@ -108,7 +108,7 @@ jobs:
   run-maven-clm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           submodules: "true"
@@ -119,7 +119,7 @@ jobs:
           python-version: "3.8"
       - name: Run Maven
         # yamllint disable-line rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@main
+        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@46fce72e65b1838c2bfbc6ba0ad29cdd9f229303 # 2025-02-10
         with:
           jdk-version: ${{ inputs.JDK_VERSION }}
           mvn-version: ${{ inputs.MVN_VERSION }}
@@ -139,7 +139,8 @@ jobs:
         # yamllint enable rule:line-length
       - name: Nexus IQ Policy Evaluation
         continue-on-error: true
-        uses: sonatype-nexus-community/iq-github-action@master
+        # yamllint disable-line rule:line-length
+        uses: sonatype-nexus-community/iq-github-action@8d2038fbbcb37dc613c28d160843dd0981a7fce8 # v2.1.0
         with:
           serverUrl: ${{ env.NEXUS_IQ_SERVER }}
           username: ${{ vars.NEXUS_IQ_USERNAME }}

--- a/.github/workflows/composed-maven-sonar-cloud.yaml
+++ b/.github/workflows/composed-maven-sonar-cloud.yaml
@@ -119,7 +119,7 @@ jobs:
   run-maven-sonar-cloud-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           submodules: "true"
@@ -130,7 +130,7 @@ jobs:
           python-version: "3.8"
       - name: Run Maven
         # yamllint disable rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@main
+        uses: lfit/releng-reusable-workflows/.github/actions/maven-build-action@46fce72e65b1838c2bfbc6ba0ad29cdd9f229303 # 2025-02-10
         with:
           jdk-version: ${{ inputs.JDK_VERSION }}
           mvn-version: ${{ inputs.MVN_VERSION }}

--- a/.github/workflows/gerrit-ci-management-merge.yaml
+++ b/.github/workflows/gerrit-ci-management-merge.yaml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: notify
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           submodules: "true"

--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -73,7 +73,7 @@ jobs:
   rtd-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.GERRIT_BRANCH }}
           repository: ${{ inputs.TARGET_REPO }}

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -7,6 +7,7 @@
 # policy, and support documentation.
 
 name: 🔐 OpenSSF Scorecard
+# yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
   # For Branch-Protection check. Only the default branch is supported. See


### PR DESCRIPTION
A recent dependabot update highlighted several places where the actions
in use were not pinned to a specific version. This is a security risk.

* Pin versions of actions in use
* Add needed yamllint carve outs where needed to pass proper linting

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
