### PR TITLE
CI: Harden GitHub Actions

### DIFF
--- a/.github/workflows/call-gerrit-nodejs-sonatype-lifecycle.yaml
+++ b/.github/workflows/call-gerrit-nodejs-sonatype-lifecycle.yaml
@@ -80,7 +80,7 @@ jobs:
     name: "Sonatype Lifecycle Scan"
     needs: [notify, build-nodejs]
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonatype-lifecycle.yaml@main
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonatype-lifecycle.yaml@722992887e1d5a032146db18e2e00adf78ff168e # 2025-02-11
     secrets:
       NEXUS_IQ_PASSWORD: ${{ secrets.NEXUS_IQ_PASSWORD }}
 
@@ -90,7 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get workflow conclusion
-        uses: technote-space/workflow-conclusion-action@v3
+        # yamllint disable-line rule:line-length
+        uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
       - name: Report workflow conclusion
         # yamllint disable-line rule:line-length
         uses: lfit/gerrit-review-action@9627b9a144f2a2cad70707ddfae87c87dce60729 # v0.8

--- a/.github/workflows/composed-tox-sonar-cloud.yaml
+++ b/.github/workflows/composed-tox-sonar-cloud.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Run tox verify
         id: tox-verify
         # yamllint disable-line rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/workflows/gerrit-compose-required-tox-verify.yaml@main
+        uses: lfit/releng-reusable-workflows/.github/workflows/gerrit-compose-required-tox-verify.yaml@722992887e1d5a032146db18e2e00adf78ff168e # 2025-02-11
         with:
           GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
           GERRIT_CHANGE_ID: ${{ inputs.GERRIT_CHANGE_ID }}

--- a/.github/workflows/gerrit-compose-required-tox-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-tox-verify.yaml
@@ -118,7 +118,7 @@ jobs:
           repository: ${{ inputs.TARGET_REPO }}
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
       - name: Actions checkout # Needed for local action reference
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: lfit/releng-reusable-workflows
           sparse-checkout: .github/actions/tox-run-action

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,7 +11,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Download actionlint
         id: get_actionlint
         # yamllint disable-line rule:line-length
@@ -26,7 +26,8 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check PR for semantic commit message
-        uses: amannn/action-semantic-pull-request@v5
+        # yamllint disable-line rule:line-length
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -48,7 +49,7 @@ jobs:
           validateSingleCommitMatchesPrTitle: true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # checkout at the last commit
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

This pull request is created by [StepSecurity](https://app.stepsecurity.io/securerepo) at the request of @tykeal. Please merge the Pull Request to incorporate the requested changes. Please tag @tykeal on your message if you have any questions related to the PR.
## Security Fixes

### Pinned Dependencies

GitHub Action tags and Docker tags are mutable. This poses a security risk. GitHub's Security Hardening guide recommends pinning actions to full length commit.

- [GitHub Security Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)


## Feedback
For bug reports, feature requests, and general feedback; please email support@stepsecurity.io. To create such PRs, please visit https://app.stepsecurity.io/securerepo.

Signed-off-by: StepSecurity Bot <bot@stepsecurity.io>
Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
