### PR TITLE
Fix: Remove remnants of compound URL handling

### DIFF
--- a/.github/actions/url-validity-check-action/README.md
+++ b/.github/actions/url-validity-check-action/README.md
@@ -28,25 +28,13 @@ Uses the shell command:
 
 `wget [URL] --spider -q`
 
-## Example
-
-When providing the example inputs above to the action, the checked URL would be:
-
-`https://pypi.org/my-project/1.0.1`
-
-The full wget command in the shell:
-
-`wget https://pypi.org/my-project/1.0.1 --spider -q`
-
 ## Inputs
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name | Required | Description                       | Example            |
-| ------------- | -------- | --------------------------------- | ------------------ |
-| URL           | True     | Primary URL to check              | <https://pypi.org> |
-| STRING        | False    | Intermediate string to add to URL | /my-project        |
-| SUFFIX        | False    | Suffix to add to URL              | /1.0.1             |
+| Input | Required | Description  | Example                     |
+| ----- | -------- | ------------ | --------------------------- |
+| URL   | True     | URL to check | <https://linuxfoundation.org> |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/.github/actions/url-validity-check-action/action.yaml
+++ b/.github/actions/url-validity-check-action/action.yaml
@@ -7,16 +7,9 @@ name: "🌍 Check URL for Validity with WGET"
 description: "Tests a give URL for a valid server response"
 
 inputs:
-  # Allows for compound URLs built from three separate components
   URL:
-    description: "URL prefix to check"
+    description: "Remote URL to check"
     required: true
-  STRING:
-    description: "Check URL for presence of this project/name"
-    required: false
-  SUFFIX:
-    description: "URL suffix to append"
-    required: false
 
 outputs:
   VALID:
@@ -50,12 +43,10 @@ runs:
       # yamllint disable rule:line-length
       run: |
         # Check URL for Validity
-        if (wget ${{ inputs.PREFIX }}${{ inputs.STRING }}${{ inputs.SUFFIX }} --spider -q); then
-          echo "URL/location WAS found and valid ✅"
-          echo "${{ inputs.PREFIX }}${{ inputs.STRING }}${{ inputs.SUFFIX }}"
+        if (wget ${{ inputs.url }} --spider -q); then
+          echo "URL/location was found and valid ✅"
           echo "valid=true" >> "$GITHUB_OUTPUT"
         else
           echo "URL/location was NOT found/valid ❌"
-          echo "${{ inputs.PREFIX }}${{ inputs.STRING }}${{ inputs.SUFFIX }}"
           echo "valid=false" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
A bug was introduced at the time this action was imported/migrated over from OS Climate. Previously, it was used to build compound URLs for checking PyPI packages. That functionality was replaced, and this action should be simplfied to perform a basic action. Any compoound handling of URLs needs to be performed elsewhere.