### PR TITLE
Fix: Remove prettier due to various ongoing issues/maintenance concerns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,11 +50,6 @@ repos:
       - id: ruff-format
         files: ^(scripts|tests|custom_components)/.+\.py$
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: f40886d54c729f533f864ed6ce584e920feb0af7 # frozen: v1.15.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-SPDX-License-Identifier: Apache-2.0
-SPDX-FileCopyrightText: 2025 The Linux Foundation
-
-# Prettier prior to 3.4.0 has an issue affecting markdown:
-# See: https://prettier.io/blog/2024/11/26/3.4.0/
-
-# Ignore markdown files; leave them to markdownlint
-**/*.md


### PR DESCRIPTION
Looks like the recent .prettierignore addition has introduced occasional linting failures (this does not happen every time linting runs). e.g.

prettier.................................................................Failed [error] No files matching the given patterns were found

This change removes its configuration and we will rely on other tools going forward.