### PR TITLE
Feat: Additional parsing steps and outputs in git-commit-message-action

### DIFF
--- a/.github/actions/git-commit-message-action/README.md
+++ b/.github/actions/git-commit-message-action/README.md
@@ -5,8 +5,9 @@ SPDX-FileCopyrightText: 2024 The Linux Foundation
 
 # 💬 GIT Commit Message
 
-Action that returns the last/current commit message to a calling GitHub
-action/workflow.
+Returns the commit SHA and message for a given (numbered) commit. Defaults to
+the latest commit if no commit number supplied as input. Also checks the commit
+message body for a Gerrit Change-Id and DCO line.
 
 ## git-commit-message-action
 
@@ -18,31 +19,49 @@ actions/workflows.
 ```yaml
 - name: "Retrieve GIT commit message"
   uses: lfit/releng-reusable-workflows/.github/actions/git-commit-message-action@main
+  with:
+    commit_number: 2
 ```
 
 ## Inputs
 
-This action takes/requires no explicit inputs.
+<!-- markdownlint-disable MD013 -->
+
+| Variable Name  | Mandatory  | Default | Description                                        |
+| -------------- | -----------| ------- | -------------------------------------------------- |
+| COMMIT_NUMBER  | False      | 1       | String of the last/current Git commit message body |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Outputs
 
-| Variable Name  | Description                                        |
-| -------------- | -------------------------------------------------- |
-| COMMIT_MESSAGE | String of the last/current Git commit message body |
+<!-- markdownlint-disable MD013 -->
 
-The action will exit with an error if the extracted message string is empty.
-The action produces minimal output, but does write the value received in the
-step output. The commit message string is both exported to the environment
-and written explicitly as output from the action.
+| Variable Name   | Mandatory | Description                                            |
+| --------------- | ----------| ------------------------------------------------------ |
+| COMMIT_SHA      | True      | String of the last/current Git commit message body     |
+| COMMIT_MESSAGE  | True      | String of the last/current Git commit message body     |
+| CHANGE_ID       | True      | Whether the commit message contains a Gerrit Change-Id |
+| CHANGE_ID_VALUE | False     | When Change-Id present, returns the string/value       |
+| DCO_SIGNED_OFF  | True      | Whether the commit message body contains a DCO line    |
+| DCO_NAME        | False     | Name provided in DCO statement, if present             |
+| DCO_EMAIL       | False     | E-mail address from DCO statement, if present          |
+
+<!-- markdownlint-enable MD013 -->
+
+The action will provide a warning if the extracted message string is empty.
 
 ## Requirements/Dependencies
 
-Perform a repository checkout step before using the action.
+Perform a repository checkout before using the action.
+
+The fetch depth must cover the range that includes the requested commit number.
 
 ### Internal Implementation
 
-The command used to capture the message is:
+The commands used to capture the SHA and message are:
 
 ```console
-git show -s --format='%B'
+COMMIT_SHA=$(git log --pretty=format:"%H" | awk "NR==$COMMIT_NUMBER")
+COMMIT_MESSAGE=$(git log --format=%B -n 1 "$COMMIT_SHA")
 ```

--- a/.github/actions/git-commit-message-action/README.md
+++ b/.github/actions/git-commit-message-action/README.md
@@ -37,15 +37,15 @@ actions/workflows.
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name   | Mandatory | Description                                            |
-| --------------- | ----------| ------------------------------------------------------ |
-| COMMIT_SHA      | True      | String of the last/current Git commit message body     |
-| COMMIT_MESSAGE  | True      | String of the last/current Git commit message body     |
-| CHANGE_ID       | True      | Whether the commit message contains a Gerrit Change-Id |
-| CHANGE_ID_VALUE | False     | When Change-Id present, returns the string/value       |
-| DCO_SIGNED_OFF  | True      | Whether the commit message body contains a DCO line    |
-| DCO_NAME        | False     | Name provided in DCO statement, if present             |
-| DCO_EMAIL       | False     | E-mail address from DCO statement, if present          |
+| Variable Name   | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| COMMIT_SHA      | String of the last/current Git commit message body     |
+| COMMIT_MESSAGE  | String of the last/current Git commit message body     |
+| CHANGE_ID       | Whether the commit message contains a Gerrit Change-Id |
+| CHANGE_ID_VALUE | When Change-Id present, returns the string/value       |
+| DCO_SIGNED_OFF  | Whether the commit message body contains a DCO line    |
+| DCO_NAME        | Name provided in DCO statement, if present             |
+| DCO_EMAIL       | E-mail address from DCO statement, if present          |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/.github/actions/git-commit-message-action/action.yaml
+++ b/.github/actions/git-commit-message-action/action.yaml
@@ -4,27 +4,101 @@
 
 name: "💬 GIT Commit Message"
 
+inputs:
+  COMMIT_NUMBER:
+    # Starting at one, which is the last/latest commit
+    description: "SHA value of GIT commit message to retrieve"
+    required: false
+    default: 1
+
 outputs:
+  COMMIT_SHA:
+    description: "SHA value corresponding to GIT commit number"
+    value: ${{ steps.return.outputs.commit_sha }}
   COMMIT_MESSAGE:
-    description: "GIT commit message"
+    description: "GIT commit message body"
     value: ${{ steps.return.outputs.commit_message }}
+  # See: https://gerrit-review.googlesource.com/Documentation/user-changeid.html
+  CHANGE_ID:
+    description: "Whether the commit message contains a Gerrit Change-Id"
+    value: ${{ steps.return.outputs.change_id }}
+  CHANGE_ID_VALUE:
+    description: "The extracted Change-Id value/string"
+    value: ${{ steps.return.outputs.change_id_value }}
+  # See: https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
+  DCO_SIGNED_OFF:
+    description: "Whether the commit message contains a DCO statement"
+    value: ${{ steps.return.outputs.dco_signed_off }}
+  DCO_NAME:
+    description: "Name provided in DCO statement, if present"
+    value: ${{ steps.return.outputs.dco_name }}
+  DCO_EMAIL:
+    description: "E-mail address from DCO statement, if present "
+    value: ${{ steps.return.outputs.dco_email }}
 
 runs:
   using: "composite"
   steps:
-    - name: "Retrieve GIT commit message"
+    - name: "Retrieve GIT commit"
       id: return
       shell: bash
       run: |
-        # Retrieve GIT commit message
-        COMMIT_MESSAGE=$(git show -s --format='%B')
-        if [ -z "$COMMIT_MESSAGE" ]; then
-          echo "GIT commit message string was empty ❌" >> "$GITHUB_STEP_SUMMARY"
-          echo "GIT commit message string was empty ❌"; exit 1
+        # Retrieve GIT commit
+
+        COMMIT_NUMBER="${{ inputs.COMMIT_NUMBER }}"
+        CHECK_REGEX='^[0-9]+$'
+        if ! [[ "$COMMIT_NUMBER" =~ $CHECK_REGEX ]] ; then
+           echo "Error: commit number/input must be numeric ❌"
+           exit 1
         fi
-        echo "COMMIT_MESSAGE<<EOF"$'\n'"$COMMIT_MESSAGE"$'\n'EOF >> \
+
+        COMMIT_SHA=$(git log --pretty=format:"%H" | awk "NR==$COMMIT_NUMBER")
+        COMMIT_MESSAGE=$(git log --format=%B -n 1 "$COMMIT_SHA")
+
+        CHANGE_ID_LINE=$(echo "$COMMIT_MESSAGE" | grep 'Change-Id:' || true)
+        if [ $? -ne 0 ] || [ -z "$DCO_LINE" ]; then
+          echo "Change-Id NOT found in commit message/body ⚠️"
+          CHANGE_ID="false"
+        else
+          echo "Change-Id found in commit message/body ✅"
+          CHANGE_ID="true"
+          CHANGE_ID_VALUE=$(echo "$CHANGE_ID_LINE" | awk '{ print $2 }')
+        fi
+
+        DCO_LINE=$(echo "$COMMIT_MESSAGE" | grep 'Signed-off-by:' || true)
+        if [ $? -ne 0 ] || [ -z "$DCO_LINE" ]; then
+          echo "DCO statement NOT found in commit message/body ⚠️"
+          DCO_SIGNED_OFF="false"
+        else
+          echo "DCO statement found in commit message/body ✅"
+          DCO_SIGNED_OFF="true"
+          DCO_NAME=$(echo "$DCO_LINE" | awk '{ print $2 }')
+          DCO_EMAIL=$(echo "$DCO_LINE" | awk '{ print $3 }')
+        fi
+
+        if [ -z "$COMMIT_MESSAGE" ]; then
+          echo "GIT commit message string was empty ⚠️"
+          echo "Ensure checkout step was performed"
+          echo "Ensure fetch depth covers request range"
+        fi
+
+        # Set outputs
+        echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_ENV"
+        echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+        echo "commit_message<<EOF"$'\n'"$COMMIT_MESSAGE"$'\n'EOF >> \
           "$GITHUB_ENV"
-        echo "COMMIT_MESSAGE<<EOF"$'\n'"$COMMIT_MESSAGE"$'\n'EOF >> \
+        echo "commit_message<<EOF"$'\n'"$COMMIT_MESSAGE"$'\n'EOF >> \
           "$GITHUB_OUTPUT"
+        echo "change_id=$CHANGE_ID" >> "$GITHUB_ENV"
+        echo "change_id=$CHANGE_ID" >> "$GITHUB_OUTPUT"
+        echo "change_id_value=$CHANGE_ID_VALUE">> "$GITHUB_ENV"
+        echo "change_id_value=$CHANGE_ID_VALUE" >> "$GITHUB_OUTPUT"
+        echo "dco_signed_off=$DCO_SIGNED_OFF" >> "$GITHUB_ENV"
+        echo "dco_signed_off=$DCO_SIGNED_OFF" >> "$GITHUB_OUTPUT"
+        echo "dco_name=$DCO_NAME" >> "$GITHUB_ENV"
+        echo "dco_name=$DCO_NAME" >> "$GITHUB_OUTPUT"
+        echo "dco_email=$DCO_EMAIL" >> "$GITHUB_ENV"
+        echo "dco_email=$DCO_EMAIL" >> "$GITHUB_OUTPUT"
+
         echo "GIT Commit Message 💬"
         echo "$COMMIT_MESSAGE"

--- a/.github/actions/git-commit-message-action/action.yaml
+++ b/.github/actions/git-commit-message-action/action.yaml
@@ -57,10 +57,10 @@ runs:
 
         CHANGE_ID_LINE=$(echo "$COMMIT_MESSAGE" | grep 'Change-Id:' || true)
         if [ $? -ne 0 ] || [ -z "$DCO_LINE" ]; then
-          echo "Change-Id NOT found in commit message/body ⚠️"
+          echo "Gerrit Change-Id NOT found in commit message/body"
           CHANGE_ID="false"
         else
-          echo "Change-Id found in commit message/body ✅"
+          echo "Gerrit Change-Id found in commit message/body"
           CHANGE_ID="true"
           CHANGE_ID_VALUE=$(echo "$CHANGE_ID_LINE" | awk '{ print $2 }')
         fi
@@ -72,8 +72,12 @@ runs:
         else
           echo "DCO statement found in commit message/body ✅"
           DCO_SIGNED_OFF="true"
-          DCO_NAME=$(echo "$DCO_LINE" | awk '{ print $2 }')
-          DCO_EMAIL=$(echo "$DCO_LINE" | awk '{ print $3 }')
+          # Tested: https://regex101.com/r/LFOLgS/1
+          DCO_NAME=$(echo "$DCO_LINE" |\
+           grep -oP '^Signed-off-by: \K.*.+?(?= <)')
+          # Tested: https://regex101.com/r/LMK94y/1
+          DCO_EMAIL=$(echo "$DCO_LINE" |\
+           grep -oP '(?<=<).*(?=>)')
         fi
 
         if [ -z "$COMMIT_MESSAGE" ]; then


### PR DESCRIPTION
Now reports when the commit message contains a Gerrit Change-Id
and DCO signed-off-by line. Also, makes the commit number to use
a configurable input parameter.

Tested:
https://github.com/onap/portal-ng-ui/actions/runs/13700431427/job/38313059221