### PR TITLE
CI: Typo in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2023 The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
 ci:
-  autofix_commit_msg: "Chore: pre-commit autoupdate"
+  autoupdate_commit_msg: "Chore: pre-commit autoupdate"
 
 exclude: "^docs/conf.py"
 


### PR DESCRIPTION
autofix_commit_msg -> autoupdate_commit_msg

Reference: https://pre-commit.ci/#configuration-autoupdate_commit_msg