### PR TITLE
Docs: Add docs for the Github reusable workflows

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,5 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-
-Files: node_modules/**
-Copyright: 2024 The Linux Foundation
-License: Apache-2.0

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[[annotations]]
+path = "node_modules/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 The Linux Foundation"
+SPDX-License-Identifier = "Apache-2.0"

--- a/docs/compose-autotools-sonarcloud.rst
+++ b/docs/compose-autotools-sonarcloud.rst
@@ -1,0 +1,74 @@
+.. _composed-autotools-sonar-cloud-docs:
+
+#######################################
+Composed Autotools Sonar Cloud Workflow
+#######################################
+
+
+The Sonar Cloud workflow installs and runs the Sonarcloud Scanner to analyze
+code for bugs, code smells and security vulnerabilities, and to upload the result
+(possibly including code-coverage statistics) to SonarCloud.io.
+
+Optionally runs a shell script before the build to install prerequisites.
+The default configuration supplies a pre-build script that runs GNU Autotools to generate the configure shell script.
+Must be overridden if that script is in the version-control system.
+
+The worflow verifies a project by configuring the build system with autotools and analyzing
+code quality with SonarCloud. The workflow triggers when the merge job completes.
+
+1. Set up the environment for autotools and SonarCloud.
+2. Optionally run a pre-build script before verification.
+3. Configure the build system using the autotools script.
+4. Execute a SonarCloud scan to analyze the project's code quality.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+    :GERRIT_CHANGE_URL: The URL to the change.
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+    :JDK_VERSION: The OpenJDK version for the build.
+    :PRE_BUILD_SCRIPT: The pre-build script to execute before verification.
+    :PRE_BUILD_SCRIPT_PATH: The path to the pre-build script.
+    :PRE_BUILD_SCRIPT_URL: The URL of the pre-build script.
+    :SONAR_ARGS: Arguments for the SonarCloud scanner.
+    :SONAR_PROJECTBASEDIR: The directory for the `sonar.projectBaseDir` analysis property.
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarCloud access token for authentication.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: Check out the code from the Gerrit repository using the provided branch and refspec.
+
+2. **Setup Python Environment**: Set up Python 3.8 for running scripts during the build process.
+
+3. **Setup JDK**: Install the specified OpenJDK version using the `setup-java` action.
+
+4. **Pre-build Script Handling**: If provided, download and run the pre-build script to prepare the build environment. Use this for tasks like dependency installation or custom environment setup.
+
+5. **Run Autotools Script**: Run an autotools script to configure the build system.
+
+6. **Run SonarCloud Scan**: Execute a SonarCloud scan using the `sonar-scanner` tool. Configure the analysis with the provided arguments and set the `sonar.projectBaseDir` property.
+
+:Example usage:
+
+    - Trigger this workflow manually when a project change requires autotools configuration and SonarCloud analysis.
+    - Set up the build environment, run the autotools script, and perform a SonarCloud scan on the codebase.
+
+:Workflow Steps Summary:
+
+    1. Check out the Gerrit change to get the latest code.
+    2. Set up the Python environment and install OpenJDK.
+    3. Run the pre-build script (if provided).
+    4. Run the autotools script to configure the build system.
+    5. Run the SonarCloud scan to analyze the project.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-docker-verify.rst
+++ b/docs/compose-docker-verify.rst
@@ -1,0 +1,90 @@
+.. _compose-docker-verify-docs:
+
+##############################
+Compose Docker Verify Workflow
+##############################
+
+
+The workflow executes a docker build task to verify an test image build and discards the
+test image upon completion. The workflow triggers when you submit a Gerrit change request.
+
+
+It integrates with Gerrit and performs the following tasks:
+
+1. Check out the code from the Gerrit repository.
+2. Set up the Python environment for Docker-related tasks.
+3. Log in to Nexus3 and DockerHub registries using provided credentials.
+4. Retrieve the Docker image tag using specific methods.
+5. Build and push the Docker image using the retrieved tag.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: Git branch to fetch for the build.
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+    :GERRIT_CHANGE_URL: The URL to the change.
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+    :CONTAINER_TAG_METHOD: The method to locate the Docker container's tag (e.g., `latest`, `stream`, `git-describe`, or `yaml-file`).
+    :CONTAINER_TAG_YAML_DIR: The location of the YAML file with Docker tag information (required if `CONTAINER_TAG_METHOD` is `yaml-file`).
+    :DOCKER_BUILD_ARGS: Arguments for the Docker build command.
+
+:Required secrets:
+
+    :secrets.NEXUS3_PASSWORD: The Nexus3 organization's user password.
+    :secrets.DOCKERHUB_PASSWORD: The DockerHub organization's user password.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: Check out the change from the Gerrit repository using the provided refspec, project, and other inputs.
+
+2. **Setup Python Environment**: Set up Python 3.8 for Docker operations.
+
+3. **Nexus3 and DockerHub Login**: Log in to Nexus3 and DockerHub using the provided credentials to ensure the image can push to both registries.
+
+4. **Get Docker Image Tag**: Retrieve the Docker image tag based on the selected method:
+
+   - **latest**: Use the `latest` tag.
+   - **stream**: Use the branch name as the tag.
+   - **git-describe**: Use the Git description command to generate a tag.
+   - **yaml-file**: Retrieve the tag from a `container-tag.yaml` file.
+
+    :container-tag.yaml example:
+
+    .. code-block:: yaml
+
+       ---
+       tag: 1.0.0
+
+5. **Docker Build and Push**: Build and push the Docker image using the tag obtained from the previous step. Push the image to the configured registries with the specified build arguments.
+
+:Expected environment variables:
+
+    :GERRIT_URL: The base URL for Gerrit.
+    :NEXUS3_REGISTRY: The Nexus3 registry URL.
+    :DOCKERHUB_USER: The DockerHub username.
+    :NEXUS3_USER: The Nexus3 username.
+
+:Expected secrets:
+
+    :secrets.NEXUS3_PASSWORD: The Nexus3 password for authentication.
+    :secrets.DOCKERHUB_PASSWORD: The DockerHub password for authentication.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change occurs in the Docker project in Gerrit that requires building and pushing a Docker image.
+    - Use different methods for determining the Docker tag and automatically handle the build and push to the registries.
+
+:Workflow Steps Summary:
+
+    1. Check out the Gerrit change to get the latest code.
+    2. Set up the Python environment for Docker tasks.
+    3. Log in to Nexus3 and DockerHub registries.
+    4. Retrieve the Docker image tag based on the specified method.
+    5. Build the Docker image and push it to the registries.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-gradle-publish.rst
+++ b/docs/compose-gradle-publish.rst
@@ -1,0 +1,69 @@
+.. _compose-gradle-publish-docs:
+
+###############################
+Compose Gradle Publish Workflow
+###############################
+
+This workflow publishes artifacts to a Nexus repository using Gradle.
+It triggers manually via GitHub's `workflow_call` event that is  and integrates with Gerrit to perform the following tasks:
+
+1. Check out the code from the Gerrit repository.
+2. Set up the Java Development Kit (JDK) and Python environment.
+3. Build the project using Gradle.
+4. Publish the artifacts to the specified Nexus repository.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+    :GERRIT_CHANGE_URL: The URL to the change.
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+    :JDK_VERSION: The version of OpenJDK to use (default: 17).
+    :NEXUS_URL: The Nexus repository URL where you publish the artifacts.
+    :DIRECTORY: The build location of the artifacts.
+    :FILE_EXTENSION: The artifacts file extension (default: jar).
+
+:Required secrets:
+
+    :secrets.NEXUS_PASSWORD: The password for the Nexus repository.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: Check out the change from the Gerrit repository using the provided refspec, project, and other inputs.
+
+2. **Setup JDK and Python Environment**: Set up the specified JDK version and Python 3.8 for build operations.
+
+3. **Build with Gradle**: Use Gradle to build the project, creating the necessary artifacts.
+
+4. **Publish Artifacts**: Publish the built artifacts to the Nexus repository using the provided credentials and URL.
+
+:Expected environment variables:
+
+    :GERRIT_URL: The base URL for Gerrit.
+    :NEXUS_URL: The Nexus repository URL.
+
+:Expected secrets:
+
+    :secrets.NEXUS_PASSWORD: The Nexus password for authentication.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change occurs in the Gradle project in Gerrit that requires building and publishing artifacts.
+    - Use the specified JDK version and directory to handle the build and publish process.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Check out the Gerrit change to get the latest code.
+    2. Set up the JDK and Python environment.
+    3. Build the project using Gradle.
+    4. Publish the artifacts to the Nexus repository.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-info-yaml-verify.rst
+++ b/docs/compose-info-yaml-verify.rst
@@ -1,0 +1,81 @@
+.. _gerrit-compose-required-info-yaml-verify-docs:
+
+#################################################
+Gerrit Compose Required INFO Yaml Verify Workflow
+#################################################
+
+This workflow triggers when you create or update an INFO-yaml file in Gerrit.
+This job verifies that ``INFO.yaml`` file changes using the schema defined in releng/global-jjb.
+
+## Schema
+
+See: <"https://github.com/lfit/releng-global-jjb/blob/master/schema/info-schema.yaml">
+
+
+The workflow ensures the `INFO.yaml` file against a predefined schema, and confirms that the repository listed in the `INFO.yaml` matches the project from the Gerrit change.
+
+The main tasks performed by this workflow are:
+
+1. Check if you modified or created the `INFO.yaml` file.
+2. Ensure that you isolate the `INFO.yaml` changes and do not combine them with other changes.
+3. Download and check the `INFO.yaml` file against a schema.
+4. Verify that the `INFO.yaml` file lists one repository and matches the current project.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+    :GERRIT_CHANGE_URL: The URL to the change.
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+
+:Required secrets:
+
+    :secrets.GERRIT_SSH_REQUIRED_PRIVKEY: The SSH Key for the authorized user account.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: Check out the code from the Gerrit repository using the provided refspec, branch, and other inputs. Access the target repository specified in the `TARGET_REPO` input.
+
+2. **Setup Python Environment**: Set up Python 3.11 for validation tasks.
+
+3. **Verify Change Isolation**: Ensure that you isolate the `INFO.yaml` file changes and do not combine them with other file changes. If you do not find the `INFO.yaml` file or combine it with other changes, exit the workflow.
+
+4. **Download Valid Schema**: If the `INFO.yaml` file is valid and isolated, download the `info-schema.yaml` and `yaml-verify-schema.py` files from the specified URL.
+
+5. **Info File Check**: Check the `INFO.yaml` file:
+
+   - Check the syntax of the `INFO.yaml` file using `yamllint`.
+   - Check the file against the `info-schema.yaml` using `yaml-verify-schema.py`.
+   - Ensure that the `INFO.yaml` file lists one repository and matches the project specified in the Gerrit inputs.
+
+:Expected environment variables:
+
+    :GERRIT_URL: The base URL for Gerrit.
+
+:Expected secrets:
+
+    :secrets.GERRIT_SSH_REQUIRED_PRIVKEY: The SSH private key required for authentication with Gerrit.
+
+:Example usage:
+
+    - Trigger this workflow manually when a Gerrit change requires checking the `INFO.yaml` file.
+    - The workflow checks if you isolate the `INFO.yaml` file and checks it according to the predefined schema, ensuring it references the correct repository.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Check out the Gerrit change to get the latest code.
+    2. Set up the Python environment for the validation tasks.
+    3. Verify that you isolate `INFO.yaml` changes.
+    4. Download the schema and validation script.
+    5. Check the `INFO.yaml` file and ensure it matches the expected repository.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-jjb-verify.rst
+++ b/docs/compose-jjb-verify.rst
@@ -1,0 +1,75 @@
+.. _gerrit-compose-jjb-verify-docs:
+
+##################################
+Gerrit Compose JJB Verify Workflow
+##################################
+
+The JJB Verify Workflow runs when you submit a change to the Gerrit ci-management repository.
+It verifies Jenkins Job Builder (JJB) configurations in a Gerrit change. The workflow checks out the code, sets up the environment for JJB, and verifies the job configurations in the project repository.
+
+The main tasks performed by this workflow are:
+
+1. Check out the Gerrit change.
+2. Set up the Python environment for Jenkins Job Builder.
+3. Run Jenkins Job Builder (JJB) to verify the job configurations.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: Gerrit event type that triggered the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit that the change belongs to.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+
+:Required environment variables:
+
+    :vars.GERRIT_URL: The base URL for Gerrit.
+    :vars.JJB_VERSION: The version of Jenkins Job Builder to use.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow checks out the change from the Gerrit
+   repository using the provided refspec, project, and other inputs. It ensures
+   that the target repository and submodules are properly included.
+
+2. **Setup Python Environment**: The workflow sets up Python 3.11 required
+    to install and run Jenkins Job Builder.
+
+3. **Run JJB Verify**: The workflow installs the specified version of Jenkins
+   Job Builder (JJB) and runs it to verify the job configurations in the `jjb/`
+   directory. It performs the following tasks:
+
+   - Installs the required version of `jenkins-job-builder` via pip.
+   - Sets up a configuration file for Jenkins Job Builder (`jenkins_jobs.ini`).
+   - Runs the `jenkins-jobs test` command to verify the job configurations.
+
+:Example usage:
+
+    - Trigger this workflow manually when a Gerrit change involves Jenkins Job
+      Builder configurations (in the `jjb/` directory).
+    - The workflow ensures that the JJB configurations are valid and follow the
+      correct structure.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code and job configurations.
+    2. Set up Python and install the required version of Jenkins Job Builder.
+    3. Verify JJB configurations using the `jenkins-jobs test` command.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-maven-merge.rst
+++ b/docs/compose-maven-merge.rst
@@ -81,4 +81,4 @@ or hardcoding inputs/variables that apply to all repos in an organization).
     :secrets.CENTRAL_PASSWORD: Password or token for push to Maven Central.
 
 ..  # SPDX-License-Identifier: Apache-2.0
-    # SPDX-FileCopyrightText: Copyright 2024 The Linux Foundation
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-maven-verify.rst
+++ b/docs/compose-maven-verify.rst
@@ -1,0 +1,103 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _compose-maven-verify-docs:
+
+#############################
+Compose Maven Verify Workflow
+#############################
+
+It verifies the integrity and correctness of Maven-based projects by running Maven build tasks such as `clean` and `deploy`. The workflow performs the following tasks:
+
+1. Check out the code from the specified Gerrit branch.
+2. Set up the environment for Maven and Python.
+3. Run Maven to verify the project.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Optional)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Optional)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Optional)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Optional)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Optional)
+    :GERRIT_PROJECT: The project in Gerrit that the change belongs to.
+        Default: None (Optional)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Optional)
+    :JDK_VERSION: The version of OpenJDK to use for the build.
+        Default: "17" (Optional)
+    :MVN_VERSION: The version of Maven to use for the build.
+        Default: "3.8.2" (Optional)
+    :MVN_PARAMS: Parameters to pass to the Maven command.
+        Default: "" (Optional)
+    :MVN_PHASES: The phases to execute in Maven (e.g., `clean deploy`).
+        Default: "clean deploy" (Optional)
+    :MVN_OPTS: Maven options to pass during the build.
+        Default:
+        "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        -Dmaven.repo.local=/tmp/r -Dorg.ops4j.pax.url.mvn.localRepository=/tmp/r
+        -DaltDeploymentRepository=staging::default::file:"${GITHUB_WORKSPACE}"/m2repo" (Optional)
+    :MVN_POM_FILE: The path to the `pom.xml` file.
+        Default: "pom.xml" (Optional)
+    :MVN_PROFILES: A comma-delimited list of Maven profiles to activate.
+        Default: "" (Optional)
+    :MVN_GLOBAL_SETTINGS: Global settings configuration for Maven.
+        Default: ${{ vars.GLOBAL_SETTINGS }} (Optional)
+    :ENV_VARS: GitHub variables to use as environment variables during
+      the workflow execution.
+        Default: "{}" (Optional)
+    :ENV_SECRETS: GitHub secrets to use as environment variables during
+      the workflow execution.
+        Default: "{}" (Optional)
+
+:Required secrets:
+
+    :secrets.SIGUL_KEY: The key for artifact signing (if you enable signing).
+    :secrets.GHA_TOKEN: GitHub token for signing artifacts (if applicable).
+    :secrets.NEXUS_USERNAME: The username for Nexus authentication (if pushing
+      to Nexus).
+    :secrets.NEXUS_PASSWORD: The password or token for Nexus authentication
+      (if pushing to Nexus).
+    :secrets.ARTIFACTORY_ACCESS_TOKEN: The token for Artifactory access (if
+      pushing to Artifactory).
+    :secrets.CENTRAL_USERNAME: The username for Maven Central authentication
+      (if pushing to Maven Central).
+    :secrets.CENTRAL_PASSWORD: The password or token for Maven Central
+      authentication (if pushing to Maven Central).
+
+:Steps in the workflow:
+
+1. **Checkout the Code**: Begin by checking out the code from the specified Gerrit branch. Include any submodules to ensure all dependencies are up to date.
+
+2. **Setup Python Environment**: Set up Python 3.8, which you need for any Python-based tasks during the build process.
+
+3. **Run Maven Build**: Run Maven to verify the project by executing the specified Maven phases (`clean deploy` by default). Use the defined version of Maven, JDK, and any custom Maven options or parameters provided. The `pom.xml` file serves as the default, and you can specify other profiles and settings.
+
+:Expected environment variables:
+
+    :vars.GERRIT_URL: The base URL for Gerrit (needed for the checkout step).
+    :vars.GLOBAL_SETTINGS: Global settings for Maven.
+
+:Example usage:
+
+    - Trigger this workflow manually when you change the Maven-based
+      project in Gerrit that needs verification.
+    - The workflow builds the project using Maven, verifies the
+      results, and you can extend it to include more Maven phases or options.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Set up Python and Maven environments.
+    3. Run Maven to verify the project.

--- a/docs/compose-nodejs-sonatype-lifecycle.rst
+++ b/docs/compose-nodejs-sonatype-lifecycle.rst
@@ -1,0 +1,75 @@
+.. _gerrit-nodejs-sonatype-lifecycle-docs:
+
+##########################################
+Gerrit Node.js Sonatype Lifecycle Workflow
+##########################################
+
+This workflow triggers when you merge changes to a Node.js project in Gerrit.
+The workflow notifies the Gerrit system, builds the Node.js project, runs a Sonatype Lifecycle scan, and reports the scan's conclusion.
+
+The main components of this workflow include:
+
+1. Notify Gerrit about the workflow start and clear any existing votes.
+2. Build the Node.js project to integrate the latest changes.
+3. Run the Sonatype Lifecycle scan to analyze the project for security and license issues.
+4. Report the workflow conclusion back to Gerrit, indicating the result.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The ID for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit change number.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+
+:Steps in the workflow:
+
+1. **Notify Job Start**: Notify Gerrit about the job start by clearing any existing votes. Use the `gerrit-review-action` to send a notification to the Gerrit system.
+
+2. **Allow Replication**: Wait for 10 seconds to allow the replication process to complete before moving on to the next steps.
+
+3. **Build Node.js Project**: Use a reusable action (`node-build-action`) to build the Node.js project. This step ensures integration of the latest changes into the build process.
+
+4. **Sonatype Lifecycle Scan**: After building the project, trigger a Sonatype Lifecycle scan using the `reuse-sonatype-lifecycle.yaml` workflow. This step analyzes the project for security vulnerabilities, licensing issues, and other quality concerns. Use the `NEXUS_IQ_PASSWORD` secret for authentication.
+
+5. **Report Workflow Conclusion**: Report the workflow's conclusion back to Gerrit using the `gerrit-review-action`. Report the conclusion (success, failure, etc.) based on the workflow's execution results.
+
+:Expected environment variables:
+
+    :GERRIT_SERVER: The Gerrit server URL.
+    :GERRIT_SSH_USER: The SSH user for Gerrit.
+    :GERRIT_KNOWN_HOSTS: The known hosts for SSH connections to Gerrit.
+
+:Expected secrets:
+
+    :secrets.GERRIT_SSH_PRIVKEY: The private SSH key for authentication with Gerrit.
+    :secrets.NEXUS_IQ_PASSWORD: The password for Nexus IQ used in the Sonatype Lifecycle scan.
+
+:Example usage:
+
+    - Trigger this workflow manually when you make a change in the Gerrit system that requires building the Node.js project and running the Sonatype Lifecycle scan.
+    - The workflow steps ensure integration of the latest changes, conduct security and license scans, and report results back to Gerrit.
+
+:Workflow Steps Summary:
+
+    1. Notify job start to Gerrit and clear any existing votes.
+    2. Allow replication for 10 seconds.
+    3. Build the Node.js project to ensure it includes the latest changes.
+    4. Run the Sonatype Lifecycle scan for security and license compliance.
+    5. Report the conclusion of the workflow back to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-packer-verify.rst
+++ b/docs/compose-packer-verify.rst
@@ -1,0 +1,75 @@
+.. _packer-verify-docs:
+
+######################
+Packer Verify Workflow
+######################
+
+The Packer Verify Workflow verifies the change using Packer. It checks the Packer files and ensures the environment is ready to execute Packer commands. The workflow identifies changes, sets up necessary environment variables, and runs Packer checks on the templates and associated variable files.
+
+This workflow runs on GitHub when a trigger event, such as a Gerrit change or patch, occurs. It performs the following key tasks:
+
+- Check the Packer templates and variables.
+- Initialize the environment for Packer.
+- Set up dependencies for OpenStack integration.
+- Ensure the templates work as expected.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+    :GERRIT_CHANGE_URL: The URL to the change.
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+    :GERRIT_PATCHSET_NUMBER: The number of the patchset.
+    :GERRIT_PATCHSET_REVISION: The revision SHA of the patchset.
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+    :ENV_VARS: GitHub variables to export as environment variables, passed in JSON format.
+    :ENV_SECRETS: GitHub secrets to export as environment variables, passed in JSON format.
+
+:Expected environment variables:
+
+    :OS_CLOUD: The cloud provider environment to use. Default: "vex".
+    :PACKER_VERSION: The version of Packer to use. Default: "1.9.1".
+    :GERRIT_URL: The base URL for Gerrit.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: First, check out the change from Gerrit using the specified refspec, project, and URL.
+
+2. **Check for Changes**: Determine if any files in the `packer/**` directory have changed. If no changes occur, stop the workflow.
+
+3. **Setup Packer**: If changes occur, set up Packer with the specified version.
+
+4. **Export Environment Variables**: Export environment variables defined in the `ENV_VARS` input for use throughout the process.
+
+5. **Decode and Export Secrets**: Double base64 decode any secrets passed through `ENV_SECRETS` and store them as environment variables for later use.
+
+6. **Create Cloud Environment File for Packer**: Decode a base64-encoded cloud environment file and save it in the necessary format for Packer.
+
+7. **Create Cloud Configuration File for OpenStack**: Similarly, decode a base64-encoded cloud configuration file and save it to the appropriate location for OpenStack.
+
+8. **Setup Python**: Set up Python 3.11, which some validation steps require.
+
+9. **Install OpenStack Dependencies**: Install the required OpenStack client dependencies to ensure the environment is ready for testing.
+
+10. **Check Packer Files**: Verify each Packer template and associated variable files, and log the results.
+
+:Expected variables - Cloud Configuration:
+
+    :CLOUDS_ENV_2XB64: Base64-encoded cloud environment file required for Packer.
+    :CLOUDS_YAML_2XB64: Base64-encoded OpenStack YAML configuration file.
+
+:Expected variables - Secrets:
+
+    :secrets.ENV_SECRETS: Secrets passed from GitHub Actions for use during the workflow.
+
+:Comment Trigger: recheck|reverify
+
+:Example usage:
+
+    - Trigger this workflow when you change something in the Gerrit system, ensuring the environment is properly configured and validated using Packer.
+    - The variables and secrets provided ensure that the necessary configurations and credentials are securely applied throughout the process.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/compose-repository-linting.rst
+++ b/docs/compose-repository-linting.rst
@@ -1,0 +1,66 @@
+.. _compose-repo-linting-docs:
+
+###################################
+Compose Repository Linting Workflow
+###################################
+
+This workflow runs when you submit a change request to Gerrit. It lints the repository by running linting tools such as `actionlint` and `pre-commit`. The workflow performs the following tasks:
+
+1. Checks out the code from the specified Gerrit branch.
+2. Runs `actionlint` to lint GitHub Actions workflow files.
+3. Executes `pre-commit` hooks for static analysis and format checks.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :pre_commit_skips: Comma-separated list of pre-commit validators to skip,
+      defaults to `actionlint`.
+        Default: "actionlint" (Optional)
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow begins by checking out the code from the
+   specified Gerrit branch, including the changes needing linting.
+
+2. **Download actionlint**: Download `actionlint` to lint the workflow files in the repository, checking for common issues in GitHub Actions workflows.
+
+3. **Run actionlint**: Execute `actionlint` to ensure all GitHub Actions workflow files follow the correct syntax and structure.
+
+4. **Run pre-commit Hooks**: In parallel, run `pre-commit` hooks for static analysis and format checks on the codebase. Control specific checks using the `pre_commit_skips` input to skip any pre-commit hooks if necessary.
+
+:Expected environment variables:
+
+    :vars.GERRIT_URL: The base URL for Gerrit.
+
+:Example usage:
+
+    - Trigger this workflow manually when you change the repository and need linting.
+    - The workflow checks GitHub Actions workflow files with `actionlint` and runs static analysis/format checks using `pre-commit`.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Download and run `actionlint` to check the workflow files.
+    3. Run `pre-commit` hooks for static analysis and format issues.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/composed-cmake-sonar-cloud.rst
+++ b/docs/composed-cmake-sonar-cloud.rst
@@ -1,0 +1,94 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _composed-cmake-sonar-cloud-docs:
+
+###################################
+Composed Cmake Sonar Cloud Workflow
+###################################
+
+The Sonar Cloud workflow installs and runs CMake, uses the build wrapper to invoke make, then runs the Sonar Cloud Scanner
+to analyze code for bugs, code smells, and security vulnerabilities, and to upload the result (possibly including code-coverage statistics) to
+SonarCloud.io. Optionally runs a shell script before the build to install prerequisites.
+
+This workflow performs the following tasks:
+
+1. Sets up the environment for running CMake and SonarCloud.
+2. Optionally runs a pre-build script before the verification process.
+3. Executes the CMake script to configure the build system.
+4. Conducts a SonarCloud scan to analyze the project's code quality.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :JDK_VERSION: The version of OpenJDK for the build.
+        Default: "17" (Optional)
+    :PRE_BUILD_SCRIPT: The pre-build script to execute before the verify run.
+        Default: "" (Optional)
+    :PRE_BUILD_SCRIPT_PATH: The path to the pre-build script to execute before the verify run.
+        Default: "" (Optional)
+    :PRE_BUILD_SCRIPT_URL: The URL of the pre-build script to execute before the verify run.
+        Default: "" (Optional)
+    :SONAR_ARGS: Arguments to pass to the SonarCloud scanner.
+        Default: "" (Optional)
+    :SONAR_PROJECTBASEDIR: The directory for the `sonar.projectBaseDir` analysis property.
+        Default: "." (Optional)
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarCloud access token for authentication.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow starts by checking out the code from the
+   Gerrit repository based on the provided branch and refspec, including the project for analysis.
+
+2. **Setup Python Environment**: The workflow sets up Python 3.8 for running scripts required during the build process.
+
+3. **Setup JDK**: The workflow installs the specified version of OpenJDK using
+   the `setup-java` action, preparing the Java environment for the build.
+
+4. **Pre-build Script Handling**: If you provide a pre-build script via the
+   `PRE_BUILD_SCRIPT`, `PRE_BUILD_SCRIPT_PATH`, or `PRE_BUILD_SCRIPT_URL` inputs,
+   the workflow downloads and executes the script for tasks like installing dependencies or preparing the environment before verification.
+
+5. **Run CMake Script**: The workflow runs a CMake script to configure the build
+   system. It retrieves this script from a public GitHub repository and executes it to set up the project build environment.
+
+6. **Run SonarCloud Scan**: The workflow runs a SonarCloud scan to analyze
+   the codebase, using the provided arguments and setting the `sonar.projectBaseDir`
+   property based on the specified project base directory.
+
+:Example usage:
+
+    - Trigger this workflow manually when you change a project requiring CMake configuration and SonarCloud analysis.
+    - This workflow sets up the build environment, runs the CMake script, and performs a SonarCloud scan on the codebase.
+
+:Comment Trigger: ``run-sonar``
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Set up Python and OpenJDK environments.
+    3. Run the pre-build script (if provided).
+    4. Run the CMake script to configure the build system.
+    5. Run the SonarCloud scan to analyze the project.
+..
+..  # SPDX-License-Identifier: Apache-2.0

--- a/docs/composed-generic-sonar-cloud.rst
+++ b/docs/composed-generic-sonar-cloud.rst
@@ -1,0 +1,90 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _composed-generic-sonar-cloud-docs:
+
+#####################################
+Composed Generic Sonar Cloud Workflow
+#####################################
+
+The Generic Sonar Cloud workflow runs the Sonar Cloud Scanner to analyze code for bugs, code smells and security vulnerabilities, and to upload the result (possibly including code-coverage statistics)
+to SonarCloud.io. Optionally runs a shell script before the build to install prerequisites.
+
+It sets up an environment, runs a SonarCloud scan, and analyzes the project's quality. This process is essential for continuous integration (CI) and code quality checks.
+
+The workflow performs the following tasks:
+
+1. Sets up the environment for running SonarCloud scans.
+2. Optionally runs a pre-build script before the verification process.
+3. Executes a SonarCloud scan to analyze the project's code quality.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :JDK_VERSION: The version of OpenJDK for the build.
+        Default: "17" (Optional)
+    :ENV_VARS: GitHub variables passed as environment variables during the workflow execution.
+        Default: "{}" (Optional)
+    :ENV_SECRETS: GitHub secrets passed as environment variables during the workflow execution.
+        Default: "{}" (Optional)
+    :PRE_BUILD_SCRIPT: The pre-build script to execute before the verification run.
+        Default: "" (Optional)
+    :SONAR_ARGS: Arguments to pass to the SonarCloud scanner.
+        Default: "" (Optional)
+    :SONAR_PROJECTBASEDIR: The directory for the `sonar.projectBaseDir` analysis property.
+        Default: "." (Optional)
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarCloud access token for authentication.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow checks out the code from the Gerrit repository
+   based on the provided branch and refspec, ensuring analysis of the latest change.
+
+2. **Setup Python Environment**: The workflow sets up Python 3.8, necessary for running scripts during the build process.
+
+3. **Setup JDK**: The workflow installs the specified version of OpenJDK using the
+   `setup-java` action, preparing the Java environment for the build.
+
+4. **Export Environment Variables and Secrets**: The workflow exports the provided
+   environment variables and secrets into the GitHub environment, making them available during the SonarCloud scan.
+
+5. **Run Pre-build Script**: If you provide a pre-build script via the `PRE_BUILD_SCRIPT`
+   input, the workflow executes it. Use this script to set up the environment or install any dependencies before running the SonarCloud scan.
+
+6. **Run SonarCloud Scan**: The workflow runs a SonarCloud scan using the provided
+   arguments and `sonar.projectBaseDir` property, analyzing the project's code quality.
+
+:Example usage:
+
+    - Trigger this workflow manually when you change a project requiring a SonarCloud scan for quality analysis.
+    - The workflow sets up the environment, runs any pre-build scripts if provided, and then performs a SonarCloud scan to check the project's code quality.
+
+:Comment Trigger: ``run-sonar``
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Set up Python and OpenJDK environments.
+    3. Export environment variables and secrets.
+    4. Run the pre-build script (if provided).
+    5. Run the SonarCloud scan to analyze the project.

--- a/docs/composed-gradle-nexus-iq.rst
+++ b/docs/composed-gradle-nexus-iq.rst
@@ -1,0 +1,76 @@
+.. _composed-gradle-nexus-iq-docs:
+
+##########################
+Composed Gradle Nexus IQ Workflow
+##########################
+
+Gradle Nexus IQ Workflow builds a project using Gradle, runs a Nexus IQ scan, and analyzes the project's code quality. The workflow performs the following tasks:
+
+1. Sets up the environment for running Gradle and Nexus IQ scans.
+2. Runs a Gradle build and performs a Nexus IQ scan to analyze dependencies.
+3. Retrieves the application ID for the project and triggers the Sonatype lifecycle scan.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit that the change belongs to.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :JDK_VERSION: The version of OpenJDK to use for the build.
+        Default: "17" (Optional)
+    :DISTRIBUTION: The OpenJDK distribution to use (e.g., `temurin`, `zulu`, etc.).
+        Default: "temurin" (Optional)
+
+:Required secrets:
+
+    :secrets.NEXUS_IQ_PASSWORD: The Nexus IQ password or token required to access
+      the Nexus IQ server and perform scans.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow starts by checking out the code from the
+   Gerrit repository based on the provided branch and refspec. This ensures that
+   the latest change is available for the build and scan.
+
+2. **Run Gradle Build and CLM Scan**: The workflow runs a Gradle build to compile
+   the project. After the build, the Nexus IQ scan checks the project's
+   dependencies for any vulnerabilities or issues.
+
+3. **Generate Application ID**: The workflow creates an application ID based on
+   the Gerrit project and organization. This ID supports further scanning and
+   reporting within Nexus IQ.
+
+4. **Run Sonatype Lifecycle Scan**: The workflow triggers the Sonatype Lifecycle
+   scan using the generated application ID. This scan checks the project's dependencies
+   and licenses to ensure compliance.
+
+:Example usage:
+
+    - Trigger this workflow manually when a project change requires building with Gradle, scanning dependencies with Nexus IQ, and running a Sonatype Lifecycle scan.
+    - The workflow builds the project, scans for vulnerabilities, and ensures compliance.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Run Gradle build and Nexus IQ scan to analyze dependencies.
+    3. Generate the application ID for the project.
+    4. Trigger the Sonatype Lifecycle scan to check compliance.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/composed-maven-nexus-iq.rst
+++ b/docs/composed-maven-nexus-iq.rst
@@ -1,0 +1,95 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _composed-maven-nexus-iq-docs:
+
+################################
+Composed Maven Nexus IQ Workflow
+################################
+
+Maven Nexus IQ Workflow builds a Maven project, runs a Nexus IQ scan, and assesses the project's dependencies for security and compliance. The workflow performs the following tasks:
+
+1. Checks out the code from the provided Gerrit branch.
+2. Runs a Maven build and initiates a Nexus IQ scan to analyze dependencies.
+3. Generates the application ID for the project and sets it as an environment variable.
+4. Assesses the project's compliance with the policies defined in Nexus IQ.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :JDK_VERSION: The version of OpenJDK for the build.
+        Default: "17" (Optional)
+    :MVN_VERSION: The Maven version for the build.
+        Default: "3.8.2" (Optional)
+    :MVN_PARAMS: Maven parameters to pass to the `mvn` command.
+        Default: "" (Optional)
+    :MVN_PHASES: The Maven phases to execute (e.g., `clean install`).
+        Default: "" (Optional)
+    :MVN_OPTS: Maven options.
+        Default: >-
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          -Dmaven.repo.local=/tmp/r -Dorg.ops4j.pax.url.mvn.localRepository=/tmp/r
+          -DaltDeploymentRepository=staging::default::file:"${GITHUB_WORKSPACE}"/m2repo (Optional)
+    :MVN_POM_FILE: The location of the `pom.xml` file.
+        Default: "pom.xml" (Optional)
+    :MVN_PROFILES: Comma-delimited list of Maven profiles to activate.
+        Default: "" (Optional)
+    :ENV_VARS: GitHub variables passed as environment variables during
+      the workflow execution.
+        Default: "{}" (Optional)
+    :ENV_SECRETS: GitHub secrets passed as environment variables during
+      the workflow execution.
+        Default: "{}" (Optional)
+
+:Required secrets:
+
+    :secrets.NEXUS_IQ_PASSWORD: The Nexus IQ password or token for the user.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow starts by checking out the code from the
+   Gerrit repository based on the provided branch and refspec. This ensures that
+   the latest change is available for the build and Nexus IQ scan.
+
+2. **Run Maven Build**: The workflow runs a Maven build using the specified version
+   of OpenJDK and Maven, passing any parameters, phases, or options.
+   The `pom.xml` file serves as the default for running the Maven build.
+
+3. **Generate Application ID**: The workflow creates an application ID for the project
+   based on the Gerrit project and organization, storing it in the environment for
+   further use in Nexus IQ scans.
+
+4. **Nexus IQ Policy Assessment**: The workflow then triggers a Nexus IQ policy
+   assessment to check the project's dependencies. This scan identifies any security
+   vulnerabilities, licensing issues, or policy violations in the dependencies.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change occurs in a Maven-based project
+      that requires building and Nexus IQ policy assessment.
+    - The workflow runs the Maven build, checks the project's dependencies with
+      Nexus IQ, and ensures compliance with defined policies.
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Run the Maven build using the specified parameters and options.
+    3. Generate the application ID for the project.
+    4. Assess the project with Nexus IQ for security, licensing, and policy compliance.

--- a/docs/composed-maven-sonar-cloud.rst
+++ b/docs/composed-maven-sonar-cloud.rst
@@ -1,0 +1,102 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _composed-maven-sonar-cloud-docs:
+
+###################################
+Composed Maven Sonar Cloud Workflow
+###################################
+
+The Maven Sonar Cloud workflow installs the Maven, build a maven project and pushes to Sonar Cloud analyze code for bugs, code smells and security vulnerabilities, and to upload the result (possibly including code-coverage statistics)
+to SonarCloud.io. Optionally runs a shell script before the build to install prerequisites.
+
+It builds a Maven project, runs a SonarCloud scan, and analyzes the project's code quality. The workflow performs the following tasks:
+
+1. Checks out the code from the provided Gerrit branch.
+2. Runs a Maven build and initiates a SonarCloud scan to analyze the project's code quality.
+3. Provides the necessary Maven parameters, profiles, and SonarCloud configuration.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :JDK_VERSION: The version of OpenJDK for the build.
+        Default: "17" (Optional)
+    :MVN_VERSION: The Maven version for the build.
+        Default: "3.8.2" (Optional)
+    :MVN_PARAMS: Maven parameters to pass to the `mvn` command.
+        Default: "" (Optional)
+    :MVN_PHASES: The list of Maven phases to execute, such as `clean install`.
+        Default: "clean install org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.1.2184:sonar" (Optional)
+    :MVN_OPTS: Maven options.
+        Default: >-
+          -Dsonar
+          -Dsonar.host.url=https://sonarcloud.io/
+          -Dsonar.projectKey=${{ inputs.SONAR_PROJECT_KEY }}
+          -Dsonar.organization=${{ inputs.SONAR_ORG }}
+          -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        (Optional)
+    :MVN_POM_FILE: The directory containing the `pom.xml` file.
+        Default: "pom.xml" (Optional)
+    :MVN_PROFILES: A comma-delimited list of Maven profiles to activate.
+        Default: "" (Optional)
+    :SONAR_PROJECT_KEY: The dashed repo name prefixed by `<org>_`. Example: `onap_ccsdk-cds`.
+        Default: None (Required)
+    :SONAR_ORG: The organization name registered in SonarCloud.
+        Default: None (Required)
+    :SONAR_ARGS: Arguments to pass to the SonarCloud scanner.
+        Default: "" (Optional)
+    :ENV_VARS: GitHub variables passed as environment variables.
+        Default: "{}" (Optional)
+    :ENV_SECRETS: GitHub secrets passed as environment variables.
+        Default: "{}" (Optional)
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarCloud access token for authentication.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow checks out the code from the Gerrit repository
+   based on the provided branch and refspec. This ensures that the latest change
+   is available for the build and SonarCloud scan.
+
+2. **Run Maven Build**: The workflow runs a Maven build using the specified version
+   of OpenJDK and Maven, passing any parameters, phases, or options.
+   The `pom.xml` file serves as the default for running the Maven build.
+
+3. **Run SonarCloud Scan**: After the build, the workflow runs a SonarCloud scan
+   using the SonarScanner for Maven. The scan configures with the provided
+   SonarCloud project key, organization, and authentication token. You can pass arguments to the scanner for further configuration.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change occurs in a Maven-based project
+      that requires building and SonarCloud analysis for code quality.
+    - The workflow builds the project using Maven, then performs a SonarCloud scan
+      to analyze the project's code quality.
+
+:Comment Trigger: ``run-sonar``
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Run the Maven build using the specified parameters and options.
+    3. Run the SonarCloud scan to analyze the project.

--- a/docs/composed-prescan-sonar-cloud.rst
+++ b/docs/composed-prescan-sonar-cloud.rst
@@ -1,0 +1,89 @@
+.. _composed-prescan-sonar-cloud-docs:
+
+#####################################
+Composed Prescan Sonar Cloud Workflow
+#####################################
+
+This workflow triggers manually via GitHub's `workflow_call` event. It checks out the code, runs any necessary pre-build scripts, and performs a SonarCloud scan to analyze the project's code quality. This workflow is typically used for projects that require a pre-build check or analysis before the main build.
+
+The workflow performs the following tasks:
+
+1. Sets up the environment for running SonarCloud scans.
+2. Optionally runs a pre-build script to prepare the project.
+3. Executes a SonarCloud scan to analyze the project's code quality.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :JDK_VERSION: The version of OpenJDK for the build.
+        Default: "17" (Optional)
+    :PRE_BUILD_SCRIPT: The pre-build script to execute before the verification run.
+        Default: "" (Optional)
+    :PRE_BUILD_SCRIPT_PATH: The path to the pre-build script to execute before the verification run.
+        Default: "" (Optional)
+    :PRE_BUILD_SCRIPT_URL: The URL of the pre-build script to execute before the verification run.
+        Default: "" (Optional)
+    :SONAR_ARGS: Arguments to pass to the SonarCloud scanner.
+        Default: "" (Optional)
+    :SONAR_PROJECTBASEDIR: The directory for the `sonar.projectBaseDir` analysis property.
+        Default: "." (Optional)
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarCloud access token for authentication.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow checks out the code from the Gerrit repository
+   based on the provided branch and refspec. This ensures that the latest change
+   is available for the analysis.
+
+2. **Setup Python and JDK**: The workflow sets up Python 3.8 and the specified version
+   of OpenJDK using the `setup-java` action, ensuring the environment is ready for
+   the build process.
+
+3. **Pre-build Script**: If you provide a pre-build script via `PRE_BUILD_SCRIPT`,
+   `PRE_BUILD_SCRIPT_PATH`, or `PRE_BUILD_SCRIPT_URL`, the workflow downloads
+   and runs the script to prepare the environment. This can be useful for tasks like
+   setting up dependencies or configuring the environment before running the SonarCloud scan.
+
+4. **Run SonarCloud Scan**: The workflow runs the SonarCloud scanner to analyze the
+   project's code quality. The scan configures using the provided SonarCloud project
+   key, organization, and authentication token. You can pass arguments to
+   further configure the scan.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change occurs in a project that
+      requires SonarCloud analysis for code quality.
+    - The workflow prepares the environment, runs any pre-build scripts if provided,
+      and then performs a SonarCloud scan to analyze the codebase.
+
+:Comment Trigger: ``run-sonar``
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Set up Python and OpenJDK environments.
+    3. Run the pre-build script (if provided).
+    4. Run the SonarCloud scan to analyze the project.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/composed-tox-sonar-cloud.rst
+++ b/docs/composed-tox-sonar-cloud.rst
@@ -1,0 +1,95 @@
+.. _composed-tox-sonar-cloud-docs:
+
+#################################
+Composed Tox Sonar Cloud Workflow
+#################################
+
+Tox Sonar Cloud Workflow runs Sonar scans for Python based repos. The Tox Sonar Cloud Workflow runs a set of `tox` environments (typically for testing and linting) and then executes a SonarCloud scan to analyze the project's code quality.
+
+
+The workflow performs the following tasks:
+
+1. Sets up the environment for running `tox`.
+2. Optionally runs a pre-build script to prepare the project.
+3. Runs the specified `tox` environments.
+4. Executes a SonarCloud scan to analyze the project's code quality.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :SONAR_ARGS: Arguments to pass to the SonarCloud scanner.
+        Default: "" (Optional)
+    :SONAR_PROJECTBASEDIR: The directory for the `sonar.projectBaseDir` analysis property.
+        Default: "." (Optional)
+    :TOX_DIR: The directory containing the `tox.ini` file.
+        Default: "." (Optional)
+    :TOX_ENVS: A list of environments to run with `tox`. MUST be a
+      string representing a list of strings (e.g., '["lint", "build"]').
+        Default: None (Required)
+    :PYTHON_VERSION: The version of Python for `tox`.
+        Default: "3.12" (Optional)
+    :PARALLEL: Whether to run `tox` jobs in parallel.
+        Default: None (Optional)
+    :PRE_BUILD_SCRIPT: A pre-build script to execute before running the verification.
+        Default: "" (Optional)
+    :PRE_BUILD_SCRIPT_PATH: Path to the pre-build script to trigger before verify run.
+        Default: "" (Optional)
+    :PRE_BUILD_SCRIPT_URL: URL of the pre-build script to trigger before verify run.
+        Default: "" (Optional)
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarCloud access token for authentication.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**: The workflow starts by checking out the code from the
+   Gerrit repository based on the provided branch and refspec.
+
+2. **Run Tox**: The workflow runs the specified `tox` environments for linting, testing,
+   or building, using the provided `tox.ini` file. You can run the jobs
+   either sequentially or in parallel.
+
+3. **Run Pre-build Script**: If a pre-build script exists, execute it
+   before running the `tox` environments. This script can handle tasks such as
+   installing dependencies or configuring the environment.
+
+4. **SonarCloud Scan**: After the `tox` jobs, the workflow runs a SonarCloud scan
+   to analyze the project’s code quality. The SonarCloud scanner configures
+   with the provided project key, organization, and authentication token.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change occurs in a project that
+      requires running `tox` environments and performing SonarCloud analysis.
+    - The workflow runs the specified `tox` environments, runs a SonarCloud scan,
+      and analyzes the project.
+
+:Comment Trigger: ``run-sonar``
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change to get the latest code.
+    2. Set up Python and `tox` environments.
+    3. Run the specified `tox` environments for testing and linting.
+    4. Run the SonarCloud scan to analyze the project.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/dependency-review.rst
+++ b/docs/dependency-review.rst
@@ -1,0 +1,36 @@
+.. _dependency-review-docs:
+
+##########################
+Dependency Review Workflow
+##########################
+
+This Dependency Review Workflow scans dependency manifest files that change as part of a pull request. It surfaces known-vulnerable versions of the packages declared or updated in the pull request. When the workflows runs, it prevents pull requests that introduce known-vulnerable packages from merging.
+
+### Trigger Events:
+
+- **pull_request**: Activates when someone creates or updates a pull request.
+
+### Required Permissions:
+
+    :contents: read - Required to allow the workflow to read the contents of the repository.
+
+### Workflow Steps:
+
+1. **Checkout Repository**:
+   The workflow checks out the repository using the `actions/checkout` action. This step ensures that the code from the pull request is available for review and dependency checks.
+
+2. **Dependency Review**:
+   The workflow uses the `actions/dependency-review-action` to perform a dependency review. It scans the dependency manifest files to identify any known-vulnerable packages and surfaces them. If it finds any vulnerabilities, it reports them, and the review settings may prevent the pull request from merging.
+
+### Example Usage:
+
+- This workflow automatically activates whenever someone creates or updates a pull request. It reviews the dependencies of the change and surfaces any vulnerabilities found in the updated or added packages.
+
+### Workflow Steps Summary:
+
+    1. Checkout the repository to ensure the latest changes undergo review.
+    2. Scan the dependencies in the manifest files for vulnerabilities using the `dependency-review-action`.
+    3. Surface any known vulnerabilities and, if necessary, prevent the merging of the pull request.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-ci-management-merge.rst
+++ b/docs/gerrit-ci-management-merge.rst
@@ -1,0 +1,76 @@
+.. _gerrit-ci-management-merge-docs:
+
+###################################
+Gerrit ci-management Merge Workflow
+###################################
+
+The ci-management Merge Workflow manages the merge process of a change in Gerrit and runs Jenkins Job Builder (JJB) to apply the configuration changes.
+The workflow reports the conclusion back to Gerrit.
+
+The workflow performs the following tasks:
+
+1. Notifies the job start and clears any previous votes in Gerrit.
+2. Merges the JJB configuration using the Gerrit change details.
+3. Reports the workflow conclusion back to Gerrit.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+
+:Required secrets:
+
+    :secrets.JOBBUILDER_PROD_PSW: Jenkins admin user account token.
+    :secrets.GERRIT_SSH_PRIVKEY: Private SSH key used for leaving comments in Gerrit.
+
+:Steps in the workflow:
+
+1. **Notify Job Start**: The workflow notifies the start of the job and clears
+   any existing votes in Gerrit using the `gerrit-review-action`.
+
+2. **JJB Merge**: The workflow uses `jenkins-job-builder` (JJB) to merge
+   the Jenkins jobs configuration by applying the changes to the Jenkins server. It
+   installs the necessary Python dependencies and configures JJB using the provided
+   credentials and configuration files.
+
+3. **Clean Up**: After merging, the workflow cleans up any temporary files created
+   during the process, including configuration files and property files.
+
+4. **Report Workflow Conclusion**: The workflow reports the conclusion
+   to Gerrit using the `gerrit-review-action`. This includes updating
+   the Gerrit change with the result of the workflow.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change in Gerrit requires applying
+      configuration changes via Jenkins Job Builder.
+    - The workflow updates the jobs and applies the changes while reporting
+      the status back to Gerrit.
+
+:Comment Trigger: ``remerge``
+
+:Workflow Steps Summary:
+
+    1. Notify the start of the job and clear any previous votes in Gerrit.
+    2. Use Jenkins Job Builder to apply the changes.
+    3. Clean up temporary files.
+    4. Report the workflow conclusion back to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-ci-management-verify.rst
+++ b/docs/gerrit-ci-management-verify.rst
@@ -1,0 +1,81 @@
+.. _gerrit-ci-management-verify-docs:
+
+####################################
+Gerrit ci-management Verify Workflow
+####################################
+
+The ci-management Verify Workflow verifies ci-management change with the Jenkins Job Builder (JJB) verify to ensure they meet quality standards before merging.
+
+The workflow performs the following tasks:
+
+1. Notifies the job start and clears any existing votes in Gerrit.
+2. Runs the following verifications on the Gerrit change:
+    - **Actionlint**: Validates the GitHub Actions workflow files.
+    - **Pre-commit**: Runs static analysis and format checkers via `pre-commit` hooks.
+    - **Jenkins Job Builder (JJB)**: Verifies the correctness of Jenkins job configurations.
+3. Reports the workflow result back to Gerrit.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+
+:Required secrets:
+
+    :secrets.GERRIT_SSH_PRIVKEY: The SSH private key for the authorized user account to interact with Gerrit.
+
+:Steps in the workflow:
+
+1. **Notify Job Start**: The workflow clears any previous votes and notifies the start
+   of the job on the Gerrit change.
+
+2. **Actionlint Verification**: The workflow checks the validity of workflow files
+   using `actionlint`, ensuring there are no issues in the GitHub Actions configuration.
+
+3. **Pre-commit Hooks**: The workflow runs `pre-commit` hooks for static analysis and
+   format checkers, helping identify any issues in the code or formatting.
+
+4. **Jenkins Job Builder Verification**: The workflow verifies the correctness of the
+   Jenkins job configurations using `jenkins-job-builder`, ensuring that any changes to
+   the Jenkins configuration are valid.
+
+5. **Workflow Conclusion**: The workflow concludes and reports the result
+   back to Gerrit, updating the change status with the success or failure of the workflow.
+
+:Example usage:
+
+    - Trigger this workflow manually when a Gerrit change needs to undergo a series
+      of validation steps, including GitHub Actions workflow linting, code analysis
+      with `pre-commit`, and Jenkins Job Builder configuration checks.
+
+    - The workflow validates the change, provides feedback, and reports the status
+      to Gerrit for further action.
+
+:Comment Trigger: ``recheck|reverify``
+
+:Workflow Steps Summary:
+
+    1. Notify the job start and clear any previous votes in Gerrit.
+    2. Verify the GitHub Actions workflow using `actionlint`.
+    3. Run `pre-commit` hooks for static analysis and formatting checks.
+    4. Verify Jenkins job configurations using `jenkins-job-builder`.
+    5. Report the workflow conclusion back to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-compose-ci-management-verify.rst
+++ b/docs/gerrit-compose-ci-management-verify.rst
@@ -1,0 +1,72 @@
+.. _gerrit-compose-ci-management-verify-docs:
+
+############################################
+Gerrit Compose ci-management Verify Workflow
+############################################
+
+The Compose ci-management Verify Workflow is a group of jobs required to verify a ci-management change.
+It verifies changes in a Gerrit repository through checks to ensure the change meets required standards before merging.
+
+The workflow performs the following tasks:
+
+1. **Notify Job Start**: Clears any previous votes on the Gerrit change and notifies the start of the job.
+2. **Actionlint**: Validates the GitHub Actions workflow files.
+3. **Pre-commit**: Runs static analysis and format checkers using pre-commit hooks.
+4. **Jenkins Job Builder (JJB)**: Verifies the correctness of Jenkins job configurations.
+5. **Report Status**: The workflow reports the result of the checks to Gerrit.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+
+:Required secrets:
+
+    :secrets.GERRIT_SSH_PRIVKEY: The SSH private key for the authorized user account used to interact with Gerrit.
+
+:Steps in the workflow:
+
+1. **Notify Job Start**: The workflow clears any existing votes and notifies the start of the job on the Gerrit change.
+
+2. **Actionlint Verification**: The workflow checks the validity of the GitHub Actions workflow files using `actionlint`, ensuring no issues in the configuration.
+
+3. **Pre-commit Hooks**: The workflow runs `pre-commit` hooks to perform static analysis and check for formatting issues in the code.
+
+4. **Jenkins Job Builder Verification**: The workflow verifies the correctness of Jenkins job configurations using `jenkins-job-builder`, ensuring that the configuration changes are valid.
+
+5. **Workflow Conclusion**: The workflow concludes and reports the result back to Gerrit, updating the change status with the success or failure of the workflow.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change in Gerrit requires validation. The workflow performs checks, including GitHub Actions workflow linting, code analysis with `pre-commit`, and Jenkins Job Builder configuration checks.
+
+    - The workflow assesses the change and provides feedback to Gerrit.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Notify the job start and clear any previous votes in Gerrit.
+    2. Check GitHub Actions workflows with `actionlint`.
+    3. Run `pre-commit` hooks for static analysis and formatting checks.
+    4. Verify Jenkins job configurations using `jenkins-job-builder`.
+    5. Report the workflow conclusion back to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-compose-required-info-yaml-verify.rst
+++ b/docs/gerrit-compose-required-info-yaml-verify.rst
@@ -1,0 +1,66 @@
+.. _gerrit-compose-required-info-yaml-verify:
+
+#################################################
+Gerrit Compose Required INFO YAML Verify Workflow
+#################################################
+
+The Compose Required INFO YAML Verify Workflow verifies the correctness of the `INFO.yaml` file in a Gerrit change, ensuring the file remains separate from other changes, adheres to a valid schema, and matches the correct repository.
+
+### Required Parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: None (Required)
+
+### Required Secrets:
+
+    :secrets.GERRIT_SSH_REQUIRED_PRIVKEY:
+        The SSH key for the authorized user account to leave comments in Gerrit.
+
+### Workflow Steps:
+
+1. **Gerrit Checkout**:
+   The workflow checks out the specific Gerrit change based on the provided branch and refspec.
+
+2. **Verify Change Isolation**:
+   This step ensures `INFO.yaml` changes remain separate from other file changes. If other files change, the workflow fails.
+
+3. **Download Valid Schema**:
+   If the change passes the isolation test, the workflow downloads the required validation schema files (`info-schema.yaml` and `yaml-verify-schema.py`).
+
+4. **INFO.yaml File Check**:
+   The workflow uses tools (`yamllint` and a Python script) to check the `INFO.yaml` file, ensuring it follows the correct schema and contains the expected repository.
+
+### Example usage:
+
+- Trigger this workflow manually when a project change requires validating and isolating `INFO.yaml` modifications in Gerrit.
+
+:Comment Trigger: recheck|reverify
+
+### Workflow Steps Summary:
+
+    1. Checkout the Gerrit change.
+    2. Verify that `INFO.yaml` is the sole file changed.
+    3. Download the schema files for validation.
+    4. Check the `INFO.yaml` file and ensure proper formatting.
+    5. Confirm one repository appears, matching the project in Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-compose-required-rtdv3-merge.rst
+++ b/docs/gerrit-compose-required-rtdv3-merge.rst
@@ -1,0 +1,96 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _compose-rtdv3-merge-docs:
+
+############################
+Compose RTDv3 Merge Workflow
+############################
+
+The Compose RTDv3 Merge Workflow manages the merge of changes into a ReadTheDocs (RTD) project for documentation builds.
+The workflow verifies the existence of the RTD configuration, installs dependencies, and triggers the RTD build process.
+It also handles the creation and management of RTD projects and subprojects, ensuring the changes integrate properly into the documentation site.
+
+The workflow performs the following tasks:
+
+1. **Checkout Gerrit Change**: Checks out the specified Gerrit change and prepares the repository.
+2. **Install Dependencies**: Installs necessary dependencies like `lftools`, `niet`, `cryptography`, `yq`, and `tox`.
+3. **Verify ReadTheDocs Config**: Checks for the `readthedocs.yaml` configuration file in the repository.
+4. **Run RTDv3**: Triggers the RTD build process, including managing RTD projects and subprojects, and updating version information.
+5. **Merge Action**: Performs the merge operation if everything is valid and proceeds to trigger the appropriate RTD build for the specified branch.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: ${github.repository} (Optional)
+
+:Required secrets:
+
+    :secrets.RTD_TOKEN: The RTD API user token used to interact with the ReadTheDocs API.
+
+:Environment variables:
+
+    :READTHEDOCS_FOUND: A flag indicating whether the RTD config file exists.
+        Default: `true` (Optional)
+    :TOX_ENVS: The tox environments to use for the build.
+        Default: `docs, docs-linkcheck` (Optional)
+    :TOX_DIR: The directory containing the documentation for building.
+        Default: `docs/` (Optional)
+    :DOC_DIR: The directory for the generated documentation.
+        Default: `_build/html` (Optional)
+    :PARALLEL: Whether to run jobs in parallel.
+        Default: `true` (Optional)
+    :DEFAULT_VERSION: The default version for RTD.
+        Default: `latest` (Optional)
+    :MASTER_RTD_PROJECT: The main RTD project.
+        Default: `doc` (Optional)
+
+:Steps in the workflow:
+
+1. **Checkout Gerrit Change**:
+   The workflow checks out the change from the specified Gerrit repository and branch, ensuring the latest changes are available.
+
+2. **Install Dependencies**:
+   Installs dependencies like `lftools`, `niet`, `cryptography`, `yq`, and `tox`. This ensures the necessary tools are available for building and managing the RTD project.
+
+3. **Verify ReadTheDocs Config**:
+   Checks for the `readthedocs.yaml` configuration file. If absent, the process skips this step.
+
+4. **Run RTDv3**:
+   Triggers the RTD build using the `lftools` tool. This includes creating or updating the RTD project and ensuring the correct version of the documentation builds.
+
+5. **Merge Action**:
+   If the RTD project and subproject exist, the workflow performs the merge action. It updates the RTD version information and triggers the appropriate build.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change in Gerrit requires integration with RTD.
+    - The workflow verifies the RTD configuration, installs dependencies, triggers the RTD build, and handles any necessary project or subproject creation.
+
+:Comment Trigger: remerge
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change and prepare the repository.
+    2. Install the necessary dependencies for RTD and project management.
+    3. Verify if the `readthedocs.yaml` configuration file exists.
+    4. Trigger the RTD build process and handle project/subproject creation.
+    5. Perform the merge action and trigger the appropriate build for the branch.

--- a/docs/gerrit-compose-required-rtdv3-verify.rst
+++ b/docs/gerrit-compose-required-rtdv3-verify.rst
@@ -1,0 +1,105 @@
+.. # SPDX-License-Identifier: Apache-2.0
+   # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation
+
+.. _compose-rtdv3-verify-docs:
+
+#############################
+Compose RTDv3 Verify Workflow
+#############################
+
+The Compose RTDv3 Verify Workflow validates a Gerrit change against ReadTheDocs (RTD) configurations, ensuring the documentation undergoes verification before merging.
+The workflow checks for the RTD configuration, installs necessary dependencies, and performs build and version checks on the RTD project.
+
+The workflow performs the following tasks:
+
+1. **Gerrit Checkout**: Checks out the specified Gerrit change and prepares the repository.
+2. **Python Version Extraction**: Extracts the Python version from the `tox.ini` file.
+3. **Python Setup**: Sets up the appropriate Python version based on the configuration.
+4. **Install Dependencies**: Installs necessary dependencies such as `lftools`, `niet`, `cryptography`, `yq`, and `tox`.
+5. **Verify ReadTheDocs Config**: Checks for the `readthedocs.yaml` configuration file.
+6. **Run Tox**: Executes `tox` to run tests and perform static checks.
+7. **Run RTDv3**: Triggers the RTD build process, managing RTD projects and subprojects, and updating version information.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: ${github.repository} (Optional)
+
+:Required secrets:
+
+    :secrets.RTD_TOKEN: The RTD API user token used to interact with the ReadTheDocs API.
+
+:Environment variables:
+
+    :DEFAULT_PYTHON: The default Python version if not specified in the `tox.ini`.
+        Default: `3.9` (Optional)
+    :READTHEDOCS_FOUND: A flag indicating the presence of the RTD config file.
+        Default: `true` (Optional)
+    :TOX_ENVS: The tox environments for the build.
+        Default: `docs, docs-linkcheck` (Optional)
+    :TOX_DIR: The directory containing the documentation for building.
+        Default: `docs/` (Optional)
+    :DOC_DIR: The directory for the generated documentation.
+        Default: `_build/html` (Optional)
+    :PARALLEL: Whether to run jobs in parallel.
+        Default: `true` (Optional)
+    :DEFAULT_VERSION: The default version for RTD.
+        Default: `latest` (Optional)
+    :MASTER_RTD_PROJECT: The main RTD project.
+        Default: `doc` (Optional)
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**:
+   The workflow checks out the specified Gerrit change and prepares the repository.
+
+2. **Extract Python Version**:
+   The workflow extracts the Python version specified in the `tox.ini` file, ensuring the correct version applies to the documentation build.
+
+3. **Setup Python**:
+   The workflow sets up Python using the version extracted from `tox.ini` or defaults to `3.9` if unspecified.
+
+4. **Install Dependencies**:
+   Installs dependencies such as `lftools`, `niet`, `cryptography`, `yq`, and `tox` to ensure the necessary tools are available for the build.
+
+5. **Verify ReadTheDocs Config**:
+   Checks for the `readthedocs.yaml` configuration file. If absent, the process skips this step.
+
+6. **Run Tox**:
+   Executes `tox` to perform tests and checks based on the configuration. It uses `tox` environments defined in the `tox.ini` file to run documentation checks and link validation.
+
+7. **Run RTDv3**:
+   Triggers the RTD build process, creating or updating the RTD project and ensuring the correct version of the documentation builds.
+
+:Example usage:
+
+    - Trigger this workflow manually when a Gerrit change requires validation against ReadTheDocs.
+    - The workflow validates the change by running `tox` checks, verifying RTD configuration, and triggering the RTD build.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change and prepare the repository.
+    2. Extract Python version from `tox.ini` or use the default version.
+    3. Install necessary dependencies and verify RTD config.
+    4. Run `tox` to perform static analysis and format checks.
+    5. Trigger the RTD build process and ensure the documentation is up-to-date.

--- a/docs/gerrit-compose-required-tox-verify.rst
+++ b/docs/gerrit-compose-required-tox-verify.rst
@@ -1,0 +1,98 @@
+.. _compose-tox-verify-docs:
+
+###########################
+Compose Tox Verify Workflow
+###########################
+
+The Compose Tox Verify Workflow verifies changes in a Gerrit repository using `tox` environments.
+The workflow ensures proper Python version setup, verifies tox environments, and executes pre-build scripts before running the tests.
+
+The workflow performs the following tasks:
+
+1. **Gerrit Checkout**: Checks out the specified Gerrit change and prepares the repository.
+2. **Pre-build Script Handling**: Optionally, runs any pre-build scripts specified by the user.
+3. **Tox Environment Setup**: Uses `tox` environments to run tests, linters, and build processes.
+4. **Parallel Execution**: Runs `tox` in parallel across the specified environments if needed.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit that the change belongs to.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: `${{ github.repository }}` (Optional)
+    :TOX_DIR: The directory containing the `tox.ini` file.
+        Default: `"."` (Optional)
+    :TOX_ENVS: A list of environments to run. Pass this as a string representing
+    a list of strings, e.g. `'["lint", "build"]'`.
+        Default: None (Required)
+    :PYTHON_VERSION: The version of Python to use.
+        Default: `"3.12"` (Optional)
+    :PARALLEL: Whether to run jobs in parallel.
+        Default: None (Optional)
+    :PRE_BUILD_SCRIPT: A script to run before the build process begins.
+        Default: `""` (Optional)
+    :PRE_BUILD_SCRIPT_PATH: Path to the pre-build script.
+        Default: `""` (Optional)
+    :PRE_BUILD_SCRIPT_URL: URL of the pre-build script.
+        Default: `""` (Optional)
+
+:Required secrets:
+
+    :secrets.RTD_TOKEN: The RTD API user token used to interact with the ReadTheDocs API.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**:
+   The workflow checks out the specified Gerrit change and prepares the repository.
+
+2. **Pre-build Script Handling**:
+   If specified, the workflow runs any pre-build scripts. Provide this in
+   the form of a script, a path to a script, or a URL to fetch a script from.
+
+3. **Tox Environment Setup**:
+   The workflow sets up the appropriate Python environment and runs tests using `tox`.
+   It reads the Python version from the `tox.ini` file or uses the specified version.
+
+4. **Run Tox**:
+   The workflow runs `tox` environments as specified in the `TOX_ENVS` parameter. It
+   also handles parallel execution based on the `PARALLEL` parameter.
+
+5. **Parallel Execution**:
+   If the `PARALLEL` parameter equals `true`, the workflow runs the tests in parallel
+   across the specified environments.
+
+:Example usage:
+
+    - Trigger this workflow manually when a Gerrit change needs validation against
+      specific `tox` environments.
+    - The workflow validates the change by running `tox` checks, ensuring the change
+      passes the specified tests before merging.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change and prepare the repository.
+    2. Run any pre-build scripts if specified.
+    3. Run tests and checks using `tox` environments.
+    4. Run tests in parallel if specified.
+    5. Provide feedback to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-composed-ci-management-verify.rst
+++ b/docs/gerrit-composed-ci-management-verify.rst
@@ -1,0 +1,89 @@
+.. _gerrit-composed-ci-management-verify-docs:
+
+#############################################
+Gerrit Composed ci-management Verify Workflow
+#############################################
+
+
+The Compose ci-management Verify Workflow handles specific verification tasks for Gerrit changes,
+including repository linting, Jenkins Job Builder (JJB) verification, Packer verification, and voting on the change.
+
+1. Clears any existing votes on the Gerrit change.
+2. Runs repository linting to ensure the code follows the required standards.
+3. Verifies Jenkins Job Builder configurations.
+4. Verifies the Packer configurations.
+5. Votes on the Gerrit change based on the results of the verification steps.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :ENV_VARS: GitHub variables passed as environment variables during
+      the workflow execution.
+        Default: "{}" (Optional)
+
+:Required secrets:
+
+    :secrets.ENV_SECRETS: GitHub secrets passed as environment variables
+      during the workflow execution.
+    :secrets.GERRIT_SSH_PRIVKEY: SSH key for the authorized user account to
+      access Gerrit.
+    :secrets.CLOUDS_ENV_2XB64: Base64-encoded Packer cloud environment credentials.
+    :secrets.CLOUDS_YAML_2XB64: Base64-encoded Openstack cloud environment credentials.
+
+:Steps in the workflow:
+
+1. **Clear Votes**: The workflow starts by clearing any existing votes on the Gerrit
+   change using the `gerrit-review-action`.
+
+2. **Repository Linting**: The workflow runs repository linting using the
+   `compose-repo-linting` reusable workflow. This step ensures that the repository
+   adheres to the required code standards and guidelines.
+
+3. **JJB Verification**: The workflow runs Jenkins Job Builder (JJB) verification
+   using the `compose-jjb-verify` reusable workflow. This step verifies the correctness
+   of the Jenkins Job Builder configuration.
+
+4. **Packer Verification**: The workflow runs Packer verification using the
+   `compose-packer-verify` reusable workflow. This ensures that the Packer configurations
+   are valid and ready for deployment.
+
+5. **Voting**: Once all the verification steps are complete, the workflow votes
+   on the Gerrit change based on the outcome of the verification steps. The vote is
+   either positive or negative, depending on the results.
+
+:Example usage:
+
+    - Trigger this workflow manually when a Gerrit change requires repository
+      linting, JJB verification, and Packer verification.
+    - The workflow clears existing votes, runs the necessary verification steps,
+      and votes on the change based on the results.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Clear any existing votes on the Gerrit change.
+    2. Run repository linting to ensure the code meets the required standards.
+    3. Verify Jenkins Job Builder configurations.
+    4. Verify Packer configurations.
+    5. Vote on the Gerrit change based on the results.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/gerrit-required-info-yaml-verify.rst
+++ b/docs/gerrit-required-info-yaml-verify.rst
@@ -1,0 +1,86 @@
+.. _gerrit-required-info-yaml-verify-docs:
+
+#########################################
+Gerrit Required INFO Yaml Verify Workflow
+#########################################
+
+
+The Gerrit Required INFO Yaml Verify Workflow verifies changes in a Gerrit repository, specifically ensuring that the `INFO.yaml` file is properly modified and follows the necessary structure before merging.
+
+The workflow performs the following tasks:
+
+1. **Clear Votes**: Clears any existing votes on the Gerrit change to reset the status.
+2. **Gerrit Checkout**: Checks out the Gerrit change for the repository.
+3. **Verify Change Isolation**: Ensures that changes to the `INFO.yaml` file remain isolated in the commit.
+4. **Download Valid Schema**: Downloads a valid schema for the `INFO.yaml` file and prepares for validation.
+5. **Info File Validation**: Validates the `INFO.yaml` file against the downloaded schema and checks its correctness.
+6. **Set Vote**: The workflow reports the result of the checks to Gerrit, updating the change status with the success or failure of the workflow.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: None (Required)
+
+:Required secrets:
+
+    :secrets.GERRIT_SSH_REQUIRED_PRIVKEY: The SSH private key for the authorized user account
+    used to interact with Gerrit.
+
+:Steps in the workflow:
+
+1. **Clear Votes**:
+   Clears any existing votes and notifies the start of the job on the Gerrit change.
+
+2. **Gerrit Checkout**:
+   The workflow checks out the specified Gerrit change and prepares the repository.
+
+3. **Verify Change Isolation**:
+   Ensures that changes to the `INFO.yaml` file remain isolated in the commit. This helps avoid
+   combining `INFO.yaml` changes with other modifications in a single commit.
+
+4. **Download Valid Schema**:
+   If the change involves an `INFO.yaml` file, the workflow downloads a valid schema
+   (`info-schema.yaml`) and a Python script (`yaml-verify-schema.py`) for validation.
+
+5. **Info File Validation**:
+   The `INFO.yaml` file undergoes validation against the downloaded schema using `yamllint`
+   and `python yaml-verify-schema.py` to ensure that it adheres to the correct structure.
+
+6. **Set Vote**:
+   The workflow sets the Gerrit vote based on the success or failure of the validation.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change in Gerrit requires validation
+      for the correctness of the `INFO.yaml` file.
+    - The workflow will check the change and provide feedback to Gerrit.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Clear any existing votes and notify the start of the job in Gerrit.
+    2. Ensure that `INFO.yaml` file changes remain isolated in a separate commit.
+    3. Download the valid schema and check the `INFO.yaml` file.
+    4. Report the workflow conclusion back to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/openssf-scorecard.rst
+++ b/docs/openssf-scorecard.rst
@@ -1,0 +1,52 @@
+.. _openssf-scorecard:
+
+##########################
+OpenSSF Scorecard Workflow
+##########################
+
+The OpenSSF Scorecard Workflow runs the OpenSSF Scorecard to assess the security and best practices of a project. The Scorecard includes checks such as branch protection and maintenance evaluations, and it runs periodically to keep the project's security posture current.
+
+The workflow performs the following tasks:
+
+1. **Checkout Code**: The workflow checks out the code for analysis.
+2. **Run OpenSSF Scorecard**: The workflow runs the OpenSSF Scorecard to assess the repository's security posture.
+3. **Upload Results**: The workflow uploads the results of the scorecard scan.
+4. **Upload to Code Scanning Dashboard**: The workflow uploads the SARIF file to GitHub's code-scanning dashboard.
+
+:Required parameters:
+
+    :None
+
+:Required secrets:
+
+    :secrets.SONAR_TOKEN: The SonarQube API key/token.
+
+:Steps in the workflow:
+
+1. **Checkout Code**: The workflow checks out the repository code for analysis.
+
+2. **Run OpenSSF Scorecard**: The workflow uses the OpenSSF Scorecard to analyze
+   the repository, assessing it against security metrics.
+
+3. **Upload Results**: The workflow uploads the results of the scorecard scan as
+   a SARIF file.
+
+4. **Upload to Code Scanning Dashboard**: The results upload to GitHub's
+   code-scanning dashboard for review.
+
+:Example usage:
+
+    - Trigger this workflow manually or on a schedule to periodically check the
+      security posture of a repository using OpenSSF Scorecard.
+
+    - The results upload for review, helping improve the project's security.
+
+:Workflow Steps Summary:
+
+    1. Checkout the code for analysis.
+    2. Run the OpenSSF Scorecard to assess the repository's security.
+    3. Upload the results of the scan.
+    4. Upload the results to the code-scanning dashboard for visibility.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/verify-github-actions.rst
+++ b/docs/verify-github-actions.rst
@@ -1,0 +1,27 @@
+.. _reuse-verify-github-actions:
+
+####################################
+Reuse Verify GitHub Actions Workflow
+####################################
+
+This workflow ensures that action and workflow calls use specific SHA commit values.
+
+### Trigger Events:
+
+- **workflow_dispatch**: Manually trigger the workflow.
+- **pull_request**: Trigger the workflow for pull requests targeting the `main` or `master` branches, specifically for changes in the `.github/**` path.
+
+### Permissions:
+
+- This workflow does not need extra permissions.
+
+### Concurrency:
+
+- The workflow groups by `${{ github.workflow }}-${{ github.ref }}` and cancels any in-progress runs to prevent overlap.
+
+### Jobs:
+
+- **Verify**: This job uses the `lfit/releng-reusable-workflows` repository to verify GitHub Actions. It reads the contents permission and uses the workflow at the specified SHA `ac846b1cfeaf3a7cac6f28413a5206afc9951464` (version 0.2.11).
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation

--- a/docs/verify-lint.rst
+++ b/docs/verify-lint.rst
@@ -1,0 +1,50 @@
+.. _lint-github-actions-workflows:
+
+#############################
+Lint GitHub Actions Workflows
+#############################
+
+This workflow automatically lints GitHub Actions workflows and ensures that commit messages follow semantic conventions.
+
+### Trigger Events:
+
+- **push**: This workflow activates on any push event to the repository.
+- **pull_request**: This workflow also activates for pull requests, checking commit messages.
+
+### Permissions:
+
+    :contents: read
+
+### Workflow Jobs:
+
+#### 1. **actionlint**:
+   - **Runs-on**: `ubuntu-latest`
+   - **Purpose**: This job checks the formatting of GitHub Actions workflow files using `actionlint`.
+   - **Steps**:
+     - **Checkout** the repository.
+     - **Download actionlint**: Downloads the `actionlint` tool for linting workflow files.
+     - **Check workflow files**: Runs `actionlint` on all the workflow files to ensure they meet standards.
+
+#### 2. **commit-message**:
+   - **Runs-on**: `ubuntu-latest`
+   - **Condition**: This job runs when a pull request event occurs (`github.event_name == 'pull_request'`).
+   - **Purpose**: This job checks the commit message for conformity to semantic versioning conventions and ensures the commit message matches the PR title.
+   - **Steps**:
+     - **Check PR for semantic commit message**: Ensures that the pull request has a semantic commit message using the `action-semantic-pull-request` action.
+     - **Checkout the PR code**: Checks out the pull request at the last commit to review commit messages.
+     - **Install gitlint**: Installs the `gitlint` tool to review commit messages.
+     - **Run gitlint**: Runs `gitlint` on the commits to ensure they conform to the project’s commit message rules.
+
+### Example usage:
+
+- Use this workflow to automate the linting of GitHub Actions workflows, ensuring that workflow files meet formatting standards and follow best practices.
+- It also ensures that all pull request commits adhere to semantic versioning standards, providing clear and consistent commit messages.
+
+### Workflow Steps Summary:
+
+    1. Lint the GitHub Actions workflow files to ensure correctness.
+    2. Review pull request commit messages for semantic correctness.
+    3. Run `gitlint` to enforce commit message guidelines.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2025 The Linux Foundation


### PR DESCRIPTION
Add documentation for GitHub workflows in reStructuredText (.rst)
format.

- Added detailed documentation for the following GitHub workflows:
  1. Gerrit CI Management Verify Workflow
  2. Gerrit INFO YAML Verify Workflow
  3. Sonarcloud Workflows
  4. OpenSSF Scorecard Workflow
  5. Gerrit INFO YAML Verify Workflow
  6. Gerrit RTDv3 Verify and Merge
  7. Gerrit Packer Verify
  8. Compose Tox Verify
  9. Maven Workflows
  10. Gradle Workflows
  11. Repository linting
  12. Nexus IQ Workflows

Each of the .rst file includes comprehensive details on the
workflow triggers parameters, environment variables, steps, and
examples for better understanding and usage.

Note: Since write-good hook passive voice does not allow ignoring these
lines, the comment-only lines has been excluded from the documentation
until its fixed in the workflows.

In docs/gerrit-required-info-yaml-verify.rst
    :comment-only: Make this workflow advisory, default is false.
             ^^^^
"only" can weaken meaning on line 40 at column 13

Issue: IT-28142