### PR TITLE
Fix: Trigger maven-verify on relevant path changes

### DIFF
--- a/.github/workflows/zzci-test-verify-maven.yaml
+++ b/.github/workflows/zzci-test-verify-maven.yaml
@@ -5,7 +5,23 @@
 name: Verify Maven Workflows
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '.github/actions/maven-build-action/**'
+      - '.github/workflows/compose-maven-verify.yaml'
+      - '.github/workflows/compose-maven-merge.yaml'
+      - '.github/workflows/zzci-test-verify-maven.yaml'
+      - '.github/workflows/composed-maven-sonar-cloud.yaml'
+      - '.github/workflows/composed-maven-nexus-iq.yaml'
+  pull_request:
+    paths:
+      - '.github/actions/maven-build-action/**'
+      - '.github/workflows/compose-maven-verify.yaml'
+      - '.github/workflows/compose-maven-merge.yaml'
+      - '.github/workflows/zzci-test-verify-maven.yaml'
+      - '.github/workflows/composed-maven-sonar-cloud.yaml'
+      - '.github/workflows/composed-maven-nexus-iq.yaml'
 
 jobs:
   test-maven-verify:


### PR DESCRIPTION
The maven-verify workflow was being triggered unnecessarily, even when unrelated files were modified, leading to wasted compute resources. This update ensures the workflow runs only when files under the specified path are changed.