### PR TITLE
Fix: maven verify should use GERRIT_REFSPEC

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -42,7 +42,7 @@ on:
         type: string
       GERRIT_REFSPEC:
         description: "Gerrit refspec of change"
-        required: false
+        required: true
         type: string
       JDK_VERSION:
         description: "OpenJDK version"
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.GERRIT_BRANCH }}
+          ref: ${{ inputs.GERRIT_REFSPEC }}
           submodules: "true"
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/zzci-test-verify-maven.yaml
+++ b/.github/workflows/zzci-test-verify-maven.yaml
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/compose-maven-verify.yaml
     with:
       GERRIT_BRANCH: ${{ github.ref }}
+      GERRIT_REFSPEC: ${{ github.ref }}
       GERRIT_CHANGE_ID: Ic8aaa0728a43936cd4c6e1ed590e01ba8f0fbf5b
       MVN_POM_FILE: test/maven-project/pom.xml
       MVN_GLOBAL_SETTINGS: "<settings/>"

--- a/docs/compose-maven-verify.rst
+++ b/docs/compose-maven-verify.rst
@@ -32,7 +32,7 @@ It verifies the integrity and correctness of Maven-based projects by running Mav
     :GERRIT_PROJECT: The project in Gerrit that the change belongs to.
         Default: None (Optional)
     :GERRIT_REFSPEC: The refspec of the change in Gerrit.
-        Default: None (Optional)
+        Default: None (Required)
     :JDK_VERSION: The version of OpenJDK to use for the build.
         Default: "17" (Optional)
     :MVN_VERSION: The version of Maven to use for the build.


### PR DESCRIPTION
The checkout should use GERRIT_REFSPEC to checkout the actual change
rather than GERRIT_BRANCH (which checks out the current branch).

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
