### PR TITLE
Fix: Use lfit/checkout-gerrit-change-action

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -111,10 +111,13 @@ jobs:
   maven-verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@54d751e8bd167bc91f7d665dabe33fae87aaaa63 # v0.9
         with:
-          ref: ${{ inputs.GERRIT_BRANCH }}
-          submodules: "true"
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-url: ${{ vars.GERRIT_URL }}
+          repository: ${{ inputs.GERRIT_PROJECT }}
+          delay: "0s"
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         id: setup-python


### PR DESCRIPTION
Using actions/checkout is a bug since the workflows are primarily designed be used for gerrit repositories. The workflows servicing gerrit repos must use the lfit/checkout-gerrit-change-action for checkouts. This ensures the refspec is used while checking out the repo.