### PR TITLE
Fix: Use lfit/checkout-gerrit-change-action

### DIFF
--- a/.github/workflows/compose-maven-merge.yaml
+++ b/.github/workflows/compose-maven-merge.yaml
@@ -12,6 +12,10 @@ on:
         description: "Branch that change is against"
         required: true
         type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: false
+        type: string
       ARTIFACT_DIR:
         description: "Location of built artifacts"
         required: false
@@ -93,10 +97,12 @@ jobs:
   maven-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # yamllint disable-line rule:line-length
+      - uses: lfit/checkout-gerrit-change-action@54d751e8bd167bc91f7d665dabe33fae87aaaa63 # v0.9
         with:
-          ref: ${{ inputs.GERRIT_BRANCH }}
-          submodules: "true"
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-url: ${{ vars.GERRIT_URL }}
+          delay: "0s"
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         id: setup-python


### PR DESCRIPTION
Using actions/checkout is a bug since the workflows are primarily designed be used for gerrit repositories. The workflows servicing gerrit repos must use the lfit/checkout-gerrit-change-action for checkouts. This ensures the refspec is used while checking out the repo.

Note: A new GERRIT_REFSPEC param has been added to workflow_call
which needs to be updated to downstream workflows or projects.