### PR TITLE
Fix: Pass sonar token in the right section

### DIFF
--- a/.github/workflows/composed-prescan-sonar-cloud.yaml
+++ b/.github/workflows/composed-prescan-sonar-cloud.yaml
@@ -129,8 +129,7 @@ jobs:
       - name: Run Sonar Cloud scan
         # yamllint disable-line rule:line-length
         uses: lfit/releng-reusable-workflows/.github/actions/sonarqube-cloud-scan-action@2e3a6189595647fd51134412de8d7d9a56f2081c # v0.2.16
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           args: ${{ inputs.SONAR_ARGS }}
           projectBaseDir: ${{ inputs.SONAR_PROJECTBASEDIR }}


### PR DESCRIPTION
Currently we are passing the token through an env variable and it is not being read as expected. Lets move the token to an input as the sonarqube-cloud-scan-action is expecting.