### PR TITLE
Fix: pre-commit-ci autoupdate commit message format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,16 @@
 ---
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
+
 ci:
-  autofix_commit_msg: "Chore: pre-commit autoupdate"
-  autoupdate_commit_msg: "Chore: pre-commit autoupdate"
+  autofix_commit_msg: |
+    Chore: pre-commit linting updates
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+  autoupdate_commit_msg: |
+    Chore: pre-commit linting updates
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
 
 exclude: "^docs/conf.py"
 


### PR DESCRIPTION
Addresses unmergeable state of pre-commit.ci automatic updates e.g. https://github.com/lfit/releng-reusable-workflows/pull/373

Should fix gitlint complaint:

1: CC1 Body does not contain a 'Signed-off-by' line
3: B5 Body message is too short (8<20): "updates:"