### PR TITLE
Fix: Remove optional input for maven verify

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -116,7 +116,6 @@ jobs:
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           gerrit-url: ${{ vars.GERRIT_URL }}
-          repository: ${{ inputs.GERRIT_PROJECT }}
           delay: "0s"
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
The repository is already set in checkout-gerrit-change-action and not required to be passed.

Error:
Error: Invalid repository 'controller'. Expected format {owner}/{repo}.