### PR TITLE
Fix: Pass gerrit-project in compose-maven-verify

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -115,6 +115,7 @@ jobs:
       - uses: lfit/checkout-gerrit-change-action@54d751e8bd167bc91f7d665dabe33fae87aaaa63 # v0.9
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-project: ${{ inputs.GERRIT_PROJECT }}
           gerrit-url: ${{ vars.GERRIT_URL }}
           delay: "0s"
       # yamllint disable-line rule:line-length


### PR DESCRIPTION
The checkout-gerrit-change-action requires the gerrit-project input to
be passed but it was not. For some reason GitHub Actions is not failing
the workflow when it gets to the checkout step.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
