### PR TITLE
Fix: Update file-grep-regex-action to new location

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Get Python version from TOX configuration
         # yamllint disable-line rule:line-length
-        uses: lfit/releng-reusable-workflows/.github/actions/file-grep-regex-action@8c3cf221da0e47955647647c9a254c1f807081ce # v0.2.18
+        uses: lfreleng-actions/file-grep-regex-action@64fbf6bd3315530c6819e16c5b065e3bfc4f16d9 # v0.1.3
         id: python-version-from-tox
         with:
           # https://regex101.com/r/axPzef/1


### PR DESCRIPTION
Update gerrit-compose-required-rtdv3-verify.yaml to use the new lfreleng-actions/file-grep-regex-action location instead of the old lfit/releng-reusable-workflows location.

The action was migrated to lfreleng-actions on March 20, 2025 (commit 36d48dd), but the workflow was still referencing the old location at v0.2.18 which no longer contained the action.

Changes:
- From: lfit/releng-reusable-workflows/.github/actions/ file-grep-regex-action@8c3cf221 (v0.2.18)
- To:   lfreleng-actions/file-grep-regex-action@64fbf6bd
        (v0.1.3)

Fixes error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action in workflow runs.