### PR TITLE
Chore: Switch to published nexus-docker-login-action v0.4.0

### DIFF
--- a/.github/workflows/compose-docker-release-verify.yaml
+++ b/.github/workflows/compose-docker-release-verify.yaml
@@ -83,7 +83,8 @@ jobs:
         id: setup-python
         with:
           python-version: "3.8"
-      - uses: ./.github/actions/nexus-docker-login-action
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/nexus-docker-login-action@7db36e4ea24d0e9c61c930297cd810425c90ad30 # v0.4.0
         with:
           nexus3-registry: ${{ vars.NEXUS3_REGISTRY }}
           nexus3-user: ${{ vars.NEXUS3_USER }}

--- a/.github/workflows/compose-docker-verify.yaml
+++ b/.github/workflows/compose-docker-verify.yaml
@@ -89,7 +89,8 @@ jobs:
         id: setup-python
         with:
           python-version: "3.8"
-      - uses: ./.github/actions/nexus-docker-login-action
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/nexus-docker-login-action@7db36e4ea24d0e9c61c930297cd810425c90ad30 # v0.4.0
         with:
           nexus3-registry: ${{ vars.NEXUS3_REGISTRY }}
           nexus3-user: ${{ vars.NEXUS3_USER }}


### PR DESCRIPTION
Replace the two in-repo references to the local composite action
`./.github/actions/nexus-docker-login-action` with the newly released
`lfreleng-actions/nexus-docker-login-action@v0.4.0` (pinned by SHA
`7db36e4ea24d0e9c61c930297cd810425c90ad30`).

### Scope

Updated workflows:

- `.github/workflows/compose-docker-release-verify.yaml`
- `.github/workflows/compose-docker-verify.yaml`

### Sequencing note

The local action code under `.github/actions/nexus-docker-login-action/`
is intentionally **not** removed in this PR. It must remain in-tree
until a new release of `releng-reusable-workflows` is tagged with
these updated references, so downstream consumers are not broken by
a dangling local reference during the transition.

A follow-up PR can remove the local action once a release has been
cut that points at the external `lfreleng-actions` version.

### Release

- https://github.com/lfreleng-actions/nexus-docker-login-action/releases/tag/v0.4.0
