### PR TITLE
Feat: add POST_BUILD_SCRIPT support to compose-maven-verify

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -101,6 +101,21 @@ on:
         required: false
         default: "{}"
         type: string
+      POST_BUILD_SCRIPT:
+        description: "Post-build script to run after Maven build"
+        required: false
+        default: ""
+        type: string
+      POST_BUILD_SCRIPT_PATH:
+        description: "Path to post-build script to run after Maven build"
+        required: false
+        default: ""
+        type: string
+      POST_BUILD_SCRIPT_URL:
+        description: "URL of post-build script to run after Maven build"
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -110,6 +125,8 @@ concurrency:
 jobs:
   maven-verify:
     runs-on: ubuntu-latest
+    env:
+      POST_BUILD: ""
     steps:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/checkout-gerrit-change-action@8523d768952d9690702b4696a8310d2a84b1be39  # v1.0.1
@@ -137,3 +154,33 @@ jobs:
           env-vars: ${{ inputs.ENV_VARS }}
           env-secrets: ${{ inputs.ENV_SECRETS }}
           global-settings: ${{ inputs.MVN_GLOBAL_SETTINGS }}
+      - name: Post-build path
+        if: ${{ inputs.POST_BUILD_SCRIPT_PATH != '' }}
+        # yamllint disable rule:line-length
+        run: |
+          echo "POST_BUILD=${{ inputs.POST_BUILD_SCRIPT_PATH }}" >> "$GITHUB_ENV"
+        # yamllint enable rule:line-length
+      - name: Post-build script
+        if: ${{ inputs.POST_BUILD_SCRIPT != '' }}
+        run: |
+          cat > "${{ github.run_id }}.sh" << 'EOF'
+          ${{ inputs.POST_BUILD_SCRIPT }}
+          EOF
+          chmod +x "${{ github.run_id }}.sh"
+          echo "POST_BUILD=${{ github.run_id }}.sh" >> "$GITHUB_ENV"
+      - name: Post-build URL
+        if: ${{ inputs.POST_BUILD_SCRIPT_URL != '' }}
+        # yamllint disable rule:line-length
+        run: |
+          curl -fsSL "${{ inputs.POST_BUILD_SCRIPT_URL }}" > "${{ github.run_id }}.sh"
+          chmod +x "${{ github.run_id }}.sh"
+          echo "POST_BUILD=${{ github.run_id }}.sh" >> "$GITHUB_ENV"
+        # yamllint enable rule:line-length
+      - name: Run post-build
+        if: ${{ env.POST_BUILD != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::group::Post-build script output"
+          bash "$POST_BUILD"
+          echo "::endgroup::"


### PR DESCRIPTION
## Summary

Add `POST_BUILD_SCRIPT`, `POST_BUILD_SCRIPT_PATH`, and `POST_BUILD_SCRIPT_URL` optional inputs to `compose-maven-verify.yaml` reusable workflow.

## Use Case

ODL projects (e.g., yangtools) need to run tox/pytest E2E suites **after** the Maven build completes, using the freshly built artifacts in the same workspace. This was previously handled in Jenkins by running tox during the Maven build phase.

With this change, callers can specify a post-build script that runs after Maven verify, with full access to the build artifacts (local repo at `/tmp/r` and workspace).

## Example Usage

```yaml
maven-verify:
  needs: prepare
  uses: lfit/releng-reusable-workflows/.github/workflows/compose-maven-verify.yaml@main
  with:
    GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
    # ... other inputs ...
    POST_BUILD_SCRIPT: |
      pip install tox
      cd integration-tests
      tox -e pytest
```

## Non-Breaking Change

- All new inputs default to empty string
- Post-build steps are conditionally skipped when not provided
- Existing callers are unaffected
- Mirrors the existing `PRE_BUILD_SCRIPT` pattern in `gerrit-compose-required-tox-verify.yaml`

## Checklist

- [x] actionlint passes
- [x] yamllint passes
- [x] pre-commit hooks pass
- [x] Backward compatible (no changes needed for existing callers)

Ref: https://git.opendaylight.org/gerrit/c/yangtools/+/122958