### PR TITLE
Feat: add PRE_BUILD_SCRIPT support to compose-maven-verify

### DIFF
--- a/.github/workflows/compose-maven-verify.yaml
+++ b/.github/workflows/compose-maven-verify.yaml
@@ -116,6 +116,21 @@ on:
         required: false
         default: ""
         type: string
+      PRE_BUILD_SCRIPT:
+        description: "Pre-build script to run before Maven build"
+        required: false
+        default: ""
+        type: string
+      PRE_BUILD_SCRIPT_PATH:
+        description: "Path to pre-build script to run before Maven build"
+        required: false
+        default: ""
+        type: string
+      PRE_BUILD_SCRIPT_URL:
+        description: "URL of pre-build script to run before Maven build"
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -126,6 +141,7 @@ jobs:
   maven-verify:
     runs-on: ubuntu-latest
     env:
+      PRE_BUILD: ""
       POST_BUILD: ""
     steps:
       # yamllint disable-line rule:line-length
@@ -140,6 +156,35 @@ jobs:
         id: setup-python
         with:
           python-version: "3.8"
+      - name: Pre-build path
+        if: ${{ inputs.PRE_BUILD_SCRIPT_PATH != '' }}
+        # yamllint disable rule:line-length
+        run: |
+          echo "PRE_BUILD=${{ inputs.PRE_BUILD_SCRIPT_PATH }}" >> "$GITHUB_ENV"
+        # yamllint enable rule:line-length
+      - name: Pre-build script
+        if: ${{ inputs.PRE_BUILD_SCRIPT != '' }}
+        run: |
+          cat > "${{ github.run_id }}-pre.sh" << 'EOF'
+          ${{ inputs.PRE_BUILD_SCRIPT }}
+          EOF
+          chmod +x "${{ github.run_id }}-pre.sh"
+          echo "PRE_BUILD=${{ github.run_id }}-pre.sh" >> "$GITHUB_ENV"
+      - name: Pre-build URL
+        if: ${{ inputs.PRE_BUILD_SCRIPT_URL != '' }}
+        # yamllint disable rule:line-length
+        run: |
+          curl -fsSL "${{ inputs.PRE_BUILD_SCRIPT_URL }}" > "${{ github.run_id }}-pre.sh"
+          chmod +x "${{ github.run_id }}-pre.sh"
+          echo "PRE_BUILD=${{ github.run_id }}-pre.sh" >> "$GITHUB_ENV"
+        # yamllint enable rule:line-length
+      - name: Run pre-build
+        if: ${{ env.PRE_BUILD != '' }}
+        shell: bash
+        run: |
+          echo "::group::Pre-build script output"
+          bash -euo pipefail "$PRE_BUILD"
+          echo "::endgroup::"
       - name: Run Maven
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/maven-build-action@3e8765bbc2685951fb7c2be03964304179106b70 # v0.2.1
@@ -180,7 +225,6 @@ jobs:
         if: ${{ env.POST_BUILD != '' }}
         shell: bash
         run: |
-          set -euo pipefail
           echo "::group::Post-build script output"
-          bash "$POST_BUILD"
+          bash -euo pipefail "$POST_BUILD"
           echo "::endgroup::"


### PR DESCRIPTION
## Summary

Add `PRE_BUILD_SCRIPT`, `PRE_BUILD_SCRIPT_PATH`, and `PRE_BUILD_SCRIPT_URL` optional inputs to `compose-maven-verify.yaml` reusable workflow.

## Use Case

ODL projects (e.g., yangtools) where Maven's `integration-test` phase invokes tox for PyTest E2E suites. Tox must be installed **before** Maven starts since Maven itself triggers the tox command during its build lifecycle.

This was the original request from the ODL team — the previously added `POST_BUILD_SCRIPT` (PR #658) covers the case where tests run *after* Maven, but this PR covers the case where Maven *itself* needs tools installed beforehand.

## Example Usage

```yaml
maven-verify:
  needs: prepare
  uses: lfit/releng-reusable-workflows/.github/workflows/compose-maven-verify.yaml@main
  with:
    GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
    # ... other inputs ...
    PRE_BUILD_SCRIPT: |
      pip install tox
```

Or referencing a script in the repo:
```yaml
    PRE_BUILD_SCRIPT_PATH: "scripts/install-tox.sh"
```

## Non-Breaking Change

- All new inputs default to empty string
- Pre-build steps are conditionally skipped when not provided
- Existing callers are unaffected
- Mirrors the existing `PRE_BUILD_SCRIPT` pattern in `gerrit-compose-required-tox-verify.yaml`

## Execution Order

```
checkout → setup-python → PRE_BUILD_SCRIPT → Maven → POST_BUILD_SCRIPT
```

## Checklist

- [x] actionlint passes
- [x] yamllint passes
- [x] pre-commit hooks pass
- [x] Backward compatible (no changes needed for existing callers)

Ref: https://github.com/lfit/releng-reusable-workflows/issues/661