### PR TITLE
Feat: Dogfood semantic pull request workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -21,33 +21,25 @@ jobs:
         run: ${{ steps.get_actionlint.outputs.executable }} -color
         shell: bash
 
+  semantic-pull-request:
+    name: Semantic Pull Request
+    if: github.event_name == 'pull_request'
+    # Dogfood the shared reusable workflow this repository publishes. It
+    # tolerates Dependabot's truncated single-commit subjects for long
+    # dependency names that otherwise trip
+    # validateSingleCommitMatchesPrTitle.
+    # yamllint disable-line rule:line-length
+    uses: ./.github/workflows/reuse-semantic-pull-request.yaml
+    permissions:
+      contents: read
+      # The called workflow's token is capped by the caller; without this the
+      # gate step's PR API calls fail with 403 on minimal-permission repos.
+      pull-requests: read
+
   commit-message:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Check PR for semantic commit message
-        # yamllint disable-line rule:line-length
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Requires the type to be capitlized, but accept any of the standard
-          # types
-          types: |
-            Fix
-            Feat
-            Chore
-            Docs
-            Style
-            Refactor
-            Perf
-            Test
-            Revert
-            CI
-            Build
-          validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: false
-
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/docs/verify-lint.rst
+++ b/docs/verify-lint.rst
@@ -25,12 +25,22 @@ This workflow automatically lints GitHub Actions workflows and ensures that comm
      - **Download actionlint**: Downloads the `actionlint` tool for linting workflow files.
      - **Check workflow files**: Runs `actionlint` on all the workflow files to ensure they meet standards.
 
-#### 2. **commit-message**:
+#### 2. **semantic-pull-request**:
+   - **Condition**: This job runs when a pull request event occurs (`github.event_name == 'pull_request'`).
+   - **Purpose**: Validates that the pull request title follows the
+     Conventional Commits convention (with capitalised types) and, for a
+     single-commit PR, that the commit subject matches the title.
+   - **Implementation**: Delegates to the shared
+     ``reuse-semantic-pull-request`` reusable workflow published by this
+     repository, which tolerates Dependabot's truncated single-commit
+     subjects for long dependency names that would otherwise trip the
+     exact title-match check.
+
+#### 3. **commit-message**:
    - **Runs-on**: `ubuntu-latest`
    - **Condition**: This job runs when a pull request event occurs (`github.event_name == 'pull_request'`).
-   - **Purpose**: This job checks the commit message for conformity to semantic versioning conventions and ensures the commit message matches the PR title.
+   - **Purpose**: This job checks that the pull request commits conform to the project's commit message rules.
    - **Steps**:
-     - **Check PR for semantic commit message**: Ensures that the pull request has a semantic commit message using the `action-semantic-pull-request` action.
      - **Checkout the PR code**: Checks out the pull request at the last commit to review commit messages.
      - **Install gitlint**: Installs the `gitlint` tool to review commit messages.
      - **Run gitlint**: Runs `gitlint` on the commits to ensure they conform to the project’s commit message rules.


### PR DESCRIPTION
## Summary

Routes this repository's own PR-title validation through the
`reuse-semantic-pull-request` reusable workflow it publishes (added in
[v0.5.0](https://github.com/lfit/releng-reusable-workflows/releases/tag/v0.5.0)),
instead of calling `amannn/action-semantic-pull-request` directly.

## Why

`lfit/releng-reusable-workflows` is not part of the `lfreleng-actions`
organisation, has no "Mandatory workflows" ruleset, and does not consume a
shared `.github` repository, so it carries its own repo-local semantic PR
verification. That verification lived in the `commit-message` job of
`verify.yaml` and called the upstream action directly with
`validateSingleCommitMatchesPrTitle: false` — a workaround for the action's
failure on Dependabot's truncated single-commit subjects for long
dependency names (e.g. reusable workflow paths). See the failing case in
https://github.com/lfreleng-actions/tag-validate-action/pull/191.

This repository now publishes a reusable workflow that detects and
tolerates exactly that case, so it should dogfood it.

## What changed

- `verify.yaml`: extracted a dedicated `semantic-pull-request` job that
  calls `./.github/workflows/reuse-semantic-pull-request.yaml` locally
  (matching the existing local-call style used by `zzci-test-verify-maven.yaml`).
  The job is gated on `pull_request` events and grants `contents: read` plus
  `pull-requests: read`, as the reusable workflow requires.
- `verify.yaml`: the `commit-message` job now runs `gitlint` only; the
  direct `amannn/action-semantic-pull-request` step is removed.
- `docs/verify-lint.rst`: documents the new `semantic-pull-request` job and
  updates the `commit-message` job description accordingly.

## Behaviour note

The shared workflow's defaults re-enable single-commit/PR-title matching
(`validate_single_commit_matches_pr_title: true`), relaxed only for the
detected Dependabot truncation. This is stricter than the previous
`false`, but is now safe and matches the behaviour being rolled out across
`lfreleng-actions`.

## Related

Companion change in the org default repository:
`lfreleng-actions/.github` PR #40 (converts the org-wide canonical
`semantic-pull-request.yaml` to call the same reusable workflow).
