### PR TITLE
Feat: Add reusable workflows and harden egress to block mode

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -12,8 +12,44 @@ on:
       - opened
       - synchronize
       - reopened
-  # pull_request_target is required for autolabeler on PRs from forks
-  pull_request_target:
+  # pull_request_target is required for autolabeler on PRs from forks.
+  #
+  # This use of pull_request_target is safe and does NOT need
+  # manual-approval gating because:
+  #
+  #   1. The workflow performs no checkout of PR code
+  #      (no actions/checkout step), so no PR-provided source
+  #      ever runs.
+  #   2. The workflow body is loaded from the base branch
+  #      (pull_request_target semantics), not from the PR head.
+  #   3. Every step is pinned to a full commit SHA and runs
+  #      only trusted, pinned action code, never PR-provided
+  #      source. Each is a well-scoped consumer:
+  #        - `lfreleng-actions/harden-runner-block-action`
+  #          fetches one allow-list file over HTTPS, sanitises
+  #          it, and publishes it as $CONNECTION_ALLOW_LIST.
+  #          It reads no PR content.
+  #        - `step-security/harden-runner` installs the egress
+  #          block filter from $CONNECTION_ALLOW_LIST. Pure
+  #          runner-hardening; reads no PR content.
+  #        - `release-drafter/release-drafter/autolabeler`
+  #          makes only GitHub API calls; it reads PR metadata
+  #          (e.g. title and labels) to apply labels but never
+  #          checks out or runs PR head source.
+  #   4. Permissions are scoped to the minimum needed:
+  #      pull-requests: write and contents: read. No
+  #      repository secrets are passed to the job beyond the
+  #      default GITHUB_TOKEN, which the job receives with the
+  #      permissions scope above and nothing more.
+  #   5. The runner is hardened with an egress block applied
+  #      before the autolabeler step runs.
+  #
+  # See the SECURITY block on the autolabel job below for the
+  # full rationale. The zizmor `dangerous-triggers` audit is
+  # silenced here because the conditions it warns about (PR
+  # head code running with elevated privileges) cannot occur in
+  # this workflow.
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     types:
       - opened
       - synchronize
@@ -39,21 +75,38 @@ jobs:
     # SECURITY: pull_request_target with write permissions is safe here because:
     # 1. This workflow does NOT checkout any code from the PR
     # 2. The workflow code itself runs from the base branch (not the fork)
-    # 3. release-drafter only makes GitHub API calls (no code execution)
+    # 3. release-drafter runs only trusted, SHA-pinned action code and
+    #    makes GitHub API calls; it reads PR metadata but never runs
+    #    PR head source
     # 4. pull_request_target is needed ONLY for autolabeling fork PRs
     permissions:
-      # write permission is required for autolabeler
-      pull-requests: write
-      # read is sufficient; autolabeler does not create releases
-      contents: read
+      pull-requests: write  # apply labels to the pull request
+      contents: read  # read the autolabeler config from the repo
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: 'audit'
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
+      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-name: 'Autolabeler'
+name: 'Auto Label 🏷️'
 
 # yamllint disable-line rule:truthy
 on:
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   autolabel:
-    name: 'Autolabel PR'
+    name: 'Label PR'
     # Run on pull_request_target for forks, or pull_request for same-repo PRs
     # This prevents duplicate runs for same-repo PRs
     # yamllint disable rule:line-length

--- a/.github/workflows/reuse-autolabeler.yaml
+++ b/.github/workflows/reuse-autolabeler.yaml
@@ -1,0 +1,106 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Reusable pull request autolabeler.
+#
+# workflow_call counterpart to the standalone autolabeler.yaml. It applies
+# labels to pull requests using release-drafter's autolabeler entrypoint,
+# behind a block-mode harden-runner step.
+#
+# Caller requirements:
+#   - Trigger the calling workflow on BOTH pull_request and
+#     pull_request_target (opened, synchronize, reopened). The job below
+#     keys off github.event_name and the PR fork flag so same-repo PRs are
+#     labelled via pull_request and fork PRs via pull_request_target, with
+#     no duplicate runs.
+#   - The calling job inherits the permissions granted here
+#     (pull-requests: write, contents: read).
+#
+# SECURITY: it is safe to call this workflow from a pull_request_target
+# context because:
+#   1. It never checks out PR code (no actions/checkout), so no
+#      PR-provided source ever runs.
+#   2. Its body is loaded from the base branch / pinned reusable ref, not
+#      from the PR head.
+#   3. Every step is pinned to a full commit SHA and runs only trusted,
+#      pinned action code: harden-runner-block-action fetches one
+#      allow-list file over HTTPS and publishes it as
+#      $CONNECTION_ALLOW_LIST; harden-runner installs the egress block;
+#      release-drafter/autolabeler makes only GitHub API calls against PR
+#      metadata. None of them read or execute PR head source.
+#   4. Permissions stay scoped to pull-requests: write and contents: read,
+#      and the runner egress is blocked before the autolabeler step runs.
+
+name: '[R] Auto Label 🏷️'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      harden_runner_config:
+        # yamllint disable-line rule:line-length
+        description: "Allow-list source for harden-runner-block-action 'config' input"
+        required: false
+        type: string
+        # yamllint disable-line rule:line-length
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+      config_name:
+        # yamllint disable-line rule:line-length
+        description: "release-drafter config file under .github/ used for labels"
+        required: false
+        type: string
+        default: 'release-drafter.yml'
+    secrets:
+      token:
+        # yamllint disable-line rule:line-length
+        description: "Token for the autolabeler; defaults to the job's GITHUB_TOKEN"
+        required: false
+
+permissions: {}
+
+jobs:
+  autolabel:
+    name: 'Label PR'
+    # Run on pull_request_target for forks, or pull_request for same-repo
+    # PRs. This prevents duplicate runs for same-repo PRs.
+    # yamllint disable rule:line-length
+    if: >
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+    # yamllint enable rule:line-length
+    permissions:
+      pull-requests: write  # apply labels to the pull request
+      contents: read  # read the autolabeler config from the repo
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
+    steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          config: ${{ inputs.harden_runner_config }}
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
+      - name: 'Apply pull request labels'
+        # yamllint disable-line rule:line-length
+        uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
+        with:
+          config-name: ${{ inputs.config_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reuse-autolabeler.yaml
+++ b/.github/workflows/reuse-autolabeler.yaml
@@ -16,6 +16,11 @@
 #     no duplicate runs.
 #   - The calling job inherits the permissions granted here
 #     (pull-requests: write, contents: read).
+#   - A pull_request_target caller trips zizmor's dangerous-triggers
+#     audit; that finding is safe to silence with
+#     `# zizmor: ignore[dangerous-triggers]` on the caller's trigger,
+#     for the reasons in the SECURITY note below. A reusable workflow
+#     has no trigger of its own to annotate.
 #
 # SECURITY: it is safe to call this workflow from a pull_request_target
 # context because:

--- a/.github/workflows/reuse-issue-id.yaml
+++ b/.github/workflows/reuse-issue-id.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
 # Checks the commit message body for an Issue-ID, adds one when NOT present
-name: "🎟️ [R] Inject Issue-ID"
+name: "[R] Inject Issue-ID 🎟️"
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-issue-id.yaml
+++ b/.github/workflows/reuse-issue-id.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     if: vars.ISSUE_ID_LOOKUP_JSON != ''
     permissions:
-      contents: write
+      contents: write  # push the amended commit carrying the Issue-ID
     steps:
       # Load the egress allow-list out-of-band from
       # lfreleng-actions/.github and publish it as

--- a/.github/workflows/reuse-issue-id.yaml
+++ b/.github/workflows/reuse-issue-id.yaml
@@ -19,6 +19,29 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/inject-issue-id-action@689ff3a7fd1ddf8f462b1ef695d4851aaf9758b3  # v0.1.1
         with:

--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
-name: 🔐 [R] OpenSSF Scorecard
+name: "[R] OpenSSF Scorecard 🔐"
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -27,6 +27,29 @@ jobs:
       # contents: read
       # actions: read
     steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
       - name: "Checkout code"
         # yamllint disable-line rule:line-length
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -63,6 +86,29 @@ jobs:
     needs: openssf-scorecard
     runs-on: ubuntu-24.04
     steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
       - name: "Provide link to scorecard"
         # The upstream action does not provide any useful summary output
         # the action below adds a hyperlink to the OpenSSF Scorecard/report

--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -19,10 +19,8 @@ jobs:
     name: "Scan"
     runs-on: ubuntu-24.04
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write  # upload results to code scanning
+      id-token: write  # publish results and get the badge
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read

--- a/.github/workflows/reuse-python-codeql.yaml
+++ b/.github/workflows/reuse-python-codeql.yaml
@@ -37,11 +37,28 @@ jobs:
             build-mode: none
 
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
-          egress-policy: audit
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reuse-python-codeql.yaml
+++ b/.github/workflows/reuse-python-codeql.yaml
@@ -23,11 +23,9 @@ jobs:
     runs-on: ${{ matrix.language == 'swift' && 'macos-latest' || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
-      security-events: write
-      # required to fetch internal or private CodeQL packs
-      packages: read
-      # only required for workflows in private repositories
-      actions: read
+      security-events: write  # upload CodeQL SARIF results
+      packages: read  # fetch internal or private CodeQL packs
+      actions: read  # only required for private repositories
       contents: read
     strategy:
       fail-fast: false
@@ -63,6 +61,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: 'Cache dependencies'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/reuse-python-codeql.yaml
+++ b/.github/workflows/reuse-python-codeql.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
-name: "[R] CodeQL Python Scan"
+name: "[R] CodeQL Python Scan 🐍"
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-semantic-pull-request.yaml
+++ b/.github/workflows/reuse-semantic-pull-request.yaml
@@ -14,7 +14,7 @@
 # `pull-requests: read` in the caller can cause the gate's PR API calls
 # to fail with 403 on repositories that default the token to minimal
 # permissions.
-name: '[R] Semantic Pull Request'
+name: '[R] Semantic Pull Request 🛠️'
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-semantic-pull-request.yaml
+++ b/.github/workflows/reuse-semantic-pull-request.yaml
@@ -61,7 +61,7 @@ jobs:
       # the action's PR metadata lookups on repos that default the token to
       # minimal permissions. The calling job must grant this too (see the
       # caller requirement note at the top of this file).
-      pull-requests: read
+      pull-requests: read  # read PR commits and metadata for the gate
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/reuse-sha-pinned-actions.yaml
+++ b/.github/workflows/reuse-sha-pinned-actions.yaml
@@ -1,0 +1,92 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Verifies that action/workflow calls are pinned to full commit SHAs.
+#
+# workflow_call counterpart to the standalone sha-pinned-actions.yaml, and
+# a more descriptively named duplicate of reuse-verify-github-actions.yaml.
+# Unlike that workflow it exposes the underlying
+# lfreleng-actions/pinned-versions-action inputs so callers can tune the
+# scan (scope, full vs changed-files, linter version) without forking.
+#
+# The check installs gha-workflow-linter from PyPI (via uv) and queries the
+# GitHub API to validate action references. The curated egress allow-list
+# applied in block mode already permits those endpoints (api.github.com,
+# pypi.org, files.pythonhosted.org, astral.sh).
+
+name: '[R] SHA Pinned Actions 📌'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      harden_runner_config:
+        # yamllint disable-line rule:line-length
+        description: "Allow-list source for harden-runner-block-action 'config' input"
+        required: false
+        type: string
+        # yamllint disable-line rule:line-length
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+      path_prefix:
+        description: "Directory location containing project code"
+        required: false
+        type: string
+        default: '.'
+      full_scan:
+        description: "Scan the whole tree even on pull_request events"
+        required: false
+        type: boolean
+        default: false
+      linter_version:
+        # yamllint disable-line rule:line-length
+        description: "gha-workflow-linter version from PyPI (empty = latest)"
+        required: false
+        type: string
+        default: ''
+      no_checkout:
+        description: "Skip repository checkout (testing only)"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  check-actions:
+    name: 'Pinned Versions'
+    runs-on: 'ubuntu-24.04'
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          config: ${{ inputs.harden_runner_config }}
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
+      - name: 'Check Pinned Versions'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/pinned-versions-action@66ea7b539a436895f3110e3bfb78d945b2f5d927  # v0.2.0
+        with:
+          path_prefix: ${{ inputs.path_prefix }}
+          full_scan: ${{ inputs.full_scan }}
+          linter_version: ${{ inputs.linter_version }}
+          no_checkout: ${{ inputs.no_checkout }}

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
 # Runs a SonarQube Cloud scan
-name: "[R] SonarQube Cloud"
+name: "[R] SonarQube Cloud ☁️"
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -51,6 +51,29 @@ jobs:
     name: "Scan"
     runs-on: ubuntu-24.04
     steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
       - name: "SonarQube Cloud Scan"
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/sonarqube-cloud-scan-action@9e62d4bd0dda495089e97d3dd7e316abd24b5f72 # v1.1.0

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -46,10 +46,16 @@ on:
         description: "SonarQube API key/token"
         required: true
 
+# Declare default permissions as none; jobs grant the minimum they need.
+permissions: {}
+
 jobs:
   sonarqube-cloud:
     name: "Scan"
     runs-on: ubuntu-24.04
+    permissions:
+      # The scan action checks out the repository under analysis.
+      contents: read
     steps:
       # Load the egress allow-list out-of-band from
       # lfreleng-actions/.github and publish it as

--- a/.github/workflows/reuse-sonatype-lifecycle.yaml
+++ b/.github/workflows/reuse-sonatype-lifecycle.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2024 The Linux Foundation
 
 # Runs a Sonatype Lifecycle (Nexus IQ) scan
-name: "[R] sonatype-lifecycle"
+name: "[R] Sonatype Lifecycle ♻️"
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-sonatype-lifecycle.yaml
+++ b/.github/workflows/reuse-sonatype-lifecycle.yaml
@@ -51,6 +51,29 @@ jobs:
     name: "Scan"
     runs-on: ubuntu-latest
     steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
       - name: "Sonatype Lifecycle Scan"
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/sonatype-lifecycle-scan-action@e792424948d830e1d00ce828ecbcbbd40890006a  # v0.1.3

--- a/.github/workflows/reuse-sonatype-lifecycle.yaml
+++ b/.github/workflows/reuse-sonatype-lifecycle.yaml
@@ -46,10 +46,16 @@ on:
         description: "Nexus IQ Password"
         required: true
 
+# Declare default permissions as none; jobs grant the minimum they need.
+permissions: {}
+
 jobs:
   sonatype-cli:
     name: "Scan"
     runs-on: ubuntu-latest
+    permissions:
+      # The scan action checks out the repository under analysis.
+      contents: read
     steps:
       # Load the egress allow-list out-of-band from
       # lfreleng-actions/.github and publish it as

--- a/.github/workflows/reuse-verify-github-actions.yaml
+++ b/.github/workflows/reuse-verify-github-actions.yaml
@@ -18,6 +18,29 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          # yamllint disable-line rule:line-length
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
       - name: 'Check Pinned Versions'
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/pinned-versions-action@66ea7b539a436895f3110e3bfb78d945b2f5d927 # v0.2.0

--- a/.github/workflows/reuse-verify-github-actions.yaml
+++ b/.github/workflows/reuse-verify-github-actions.yaml
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Verifies action/workflow calls are pinned to SHA commit values
-name: '📌 [R] Audit GitHub Actions'
+name: '[R] Audit GitHub Actions 📌'
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/reuse-zizmor.yaml
+++ b/.github/workflows/reuse-zizmor.yaml
@@ -1,0 +1,174 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Reusable GitHub Actions security audit using zizmor.
+#
+# This is the reusable (workflow_call) counterpart to zizmor.yaml. It
+# delegates to the lfreleng-actions/zizmor-scan-action composite action,
+# which downloads a verified, attested zizmor binary, audits the calling
+# repository's workflows in SARIF mode, and writes a findings summary.
+# The action bundles (and pins) the zizmor version it installs.
+#
+# Mode: SARIF, advisory (zizmor exits 0, so this does not block merges).
+# The audit job runs with contents: read. Publishing results to the code
+# scanning dashboard is OPTIONAL and disabled by default; when enabled
+# via the upload_sarif input it runs in a separate job holding
+# security-events: write, gated to default-branch pushes (i.e. after
+# merge). Pull request runs stay advisory.
+#
+# Critical configuration is exposed as pass-through inputs so callers can
+# override the harden-runner allow-list source and the SARIF upload
+# behaviour without forking this workflow.
+
+name: '[R] Zizmor Scan 🌈'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      harden_runner_config:
+        # yamllint disable-line rule:line-length
+        description: "Allow-list source for harden-runner-block-action 'config' input"
+        required: false
+        type: string
+        # yamllint disable-line rule:line-length
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+      upload_sarif:
+        # yamllint disable-line rule:line-length
+        description: "Publish SARIF results to code scanning (default-branch pushes only)"
+        required: false
+        type: boolean
+        default: false
+      sarif_category:
+        description: "Category used to group results in code scanning"
+        required: false
+        type: string
+        default: 'zizmor'
+      artifact_name:
+        description: "Name of the SARIF artifact passed between jobs"
+        required: false
+        type: string
+        default: 'zizmor-sarif'
+      artifact_retention_days:
+        description: "Retention period (in days) for the SARIF artifact"
+        required: false
+        type: number
+        default: 5
+
+# Default to no permissions; each job grants the minimum it needs.
+permissions: {}
+
+jobs:
+  audit:
+    name: 'Audit Workflows'
+    # Skip pushes to non-default branches and tags: the optional SARIF
+    # upload is gated to default-branch pushes, so those events produce
+    # no publishable output. Pull request and workflow_dispatch events
+    # still run the advisory audit.
+    if: >-
+      github.event_name != 'push'
+      || github.ref_name == github.event.repository.default_branch
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    permissions:
+      # Only the bare minimum for the audit itself: clone the repo
+      # under audit. SARIF upload runs in a separate, gated job.
+      contents: read
+    steps:
+      # Load the egress allow-list out-of-band and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below to consume
+      # in 'block' mode. The 'config' input (overridable via the
+      # harden_runner_config workflow input) git-fetches the allow-list
+      # pinned to an immutable commit; loading out-of-band keeps the
+      # source independent of any org-level GitHub variable, which is
+      # unreachable from workflows triggered by PRs raised from forks.
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          config: ${{ inputs.harden_runner_config }}
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
+      - name: 'Checkout repository under audit'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: 'Run zizmor audit'
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/zizmor-scan-action@cb80d31aa241207c718fb34f37282acaf8bb9bdb  # v0.1.1
+
+      - name: 'Upload SARIF artifact'
+        # Only needed when SARIF publishing is enabled on a default-branch
+        # push, where the upload job consumes it; all other runs skip the
+        # upload entirely, so there is no point producing the artifact.
+        if: >-
+          inputs.upload_sarif
+          && github.event_name == 'push'
+          && github.ref_name == github.event.repository.default_branch
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: '${{ inputs.artifact_name }}'
+          path: '${{ github.workspace }}/zizmor.sarif'
+          retention-days: ${{ inputs.artifact_retention_days }}
+          if-no-files-found: 'error'
+
+  upload:
+    name: 'Publish SARIF'
+    needs: 'audit'
+    if: >-
+      inputs.upload_sarif
+      && github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    permissions:
+      security-events: write  # publish SARIF to code scanning
+      actions: read  # upload-sarif reads run info on private repos
+    steps:
+      # Load the egress allow-list out-of-band and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below to consume
+      # in 'block' mode. The 'config' input (overridable via the
+      # harden_runner_config workflow input) git-fetches the allow-list
+      # pinned to an immutable commit; loading out-of-band keeps the
+      # source independent of any org-level GitHub variable, which is
+      # unreachable from workflows triggered by PRs raised from forks.
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
+        with:
+          config: ${{ inputs.harden_runner_config }}
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
+      - name: 'Download SARIF artifact'
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: '${{ inputs.artifact_name }}'
+          path: '.'
+
+      - name: 'Upload SARIF to code scanning'
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          sarif_file: 'zizmor.sarif'
+          # Category groups these results in code scanning.
+          category: '${{ inputs.sarif_category }}'
+        continue-on-error: true

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -106,11 +106,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     permissions:
-      # Required to publish results to the code scanning dashboard.
-      security-events: write
-      # Lets upload-sarif read workflow run information on private
-      # repositories (harmless on public ones).
-      actions: read
+      security-events: write  # publish SARIF to code scanning
+      actions: read  # upload-sarif reads run info on private repos
     steps:
       # Load the egress allow-list out-of-band and publish it as
       # $CONNECTION_ALLOW_LIST for the harden-runner step below to consume

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -21,7 +21,7 @@
 # pin is now bundled in the action, so no local pin file or `pip`
 # Dependabot entry is required here.
 
-name: '🌈 Zizmor Scan'
+name: 'Zizmor Scan 🌈'
 
 # yamllint disable-line rule:truthy
 on:
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   audit:
-    name: 'Audit workflows'
+    name: 'Audit Workflows'
     # Skip pushes to non-default branches and tags: the SARIF upload is
     # gated to default-branch pushes, so those events produce no useful
     # output. Pull request and workflow_dispatch events still run.
@@ -98,7 +98,7 @@ jobs:
           if-no-files-found: 'error'
 
   upload:
-    name: 'Publish SARIF to code scanning'
+    name: 'Publish SARIF'
     needs: 'audit'
     if: >-
       github.event_name == 'push'


### PR DESCRIPTION
## Summary

Hardens the reusable workflows under `.github/workflows/` and adds three
new reusable workflows. Six atomic, signed commits.

### 1. Block-mode harden-runner (`CI:` commit)
Every `reuse-*` workflow now runs `step-security/harden-runner` in
`block` egress mode via the `lfreleng-actions/harden-runner-block-action`
wrapper, which loads the egress allow-list out-of-band and publishes it
as `$CONNECTION_ALLOW_LIST`. This removes the dependency on org-level
GitHub variables (unreachable from fork-raised PRs, which previously
forced a fallback to audit mode). `reuse-python-codeql.yaml` is flipped
from audit to block; the others gain a harden-runner step as the first
action in each job.

### 2. Permission hardening from a zizmor audit (`Fix:` commit)
- `reuse-python-codeql.yaml`: `persist-credentials: false` on checkout (`artipacked`).
- `reuse-sonarqube-cloud.yaml` / `reuse-sonatype-lifecycle.yaml`: added workflow-level `permissions: {}` and job-level `contents: read` (`excessive-permissions`). The underlying scan actions only need `contents: read` for their internal checkout.
- Inline comments on every explicit permission grant (`undocumented-permissions`), across the reuse-* workflows and the repo-local `zizmor.yaml`.

A full `zizmor --persona=auditor` (strictest) audit reports **no findings** across all reusables.

### 3. Display-name refinements (`Style:` commit)
Emoji moved to the end of each workflow's display name, plus minor name tidy-ups, across the reuse-* workflows and the repo-local `autolabeler.yaml` and `zizmor.yaml`. No behavioural change.

### 4. New reusable workflows (`Feat:` commits)
- **`reuse-zizmor.yaml`** — `workflow_call` counterpart to `zizmor.yaml`. Inputs: `harden_runner_config`, `upload_sarif` (default off; default-branch pushes only), `sarif_category`, `artifact_name`, `artifact_retention_days`.
- **`reuse-autolabeler.yaml`** — `workflow_call` counterpart to `autolabeler.yaml`. Inputs: `harden_runner_config`, `config_name`; optional `token` secret that falls back to `GITHUB_TOKEN`. Safe to call from `pull_request_target` (no PR checkout, only pinned trusted actions, scoped permissions).
- **`reuse-sha-pinned-actions.yaml`** — a more descriptively named counterpart to `reuse-verify-github-actions.yaml` that additionally exposes the `pinned-versions-action` inputs (`path_prefix`, `full_scan`, `linter_version`, `no_checkout`) plus `harden_runner_config`. The existing `reuse-verify-github-actions.yaml` is left in place for downstream callers.

## Testing
- `yamllint`, `actionlint`, `reuse lint`, `codespell`, and `check-github-workflows` (JSON schema) all pass.
- `zizmor --persona=auditor` reports no findings.
- The curated egress allow-list already permits the endpoints the scan/lint actions need (GitHub API, PyPI, astral.sh), so the SHA-pin and Sonar/Nexus reusables work under block mode.
- `gha-workflow-linter` was not run locally (sandbox blocks the GitHub API over HTTPS); all action SHAs are copied from already-pinned references, and CI runs this check.

All commits are signed and carry a DCO `Signed-off-by`.