### PR TITLE
CI(harden-runner): Update allow-list to v0.3.0

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -97,7 +97,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-autolabeler.yaml
+++ b/.github/workflows/reuse-autolabeler.yaml
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
       config_name:
         # yamllint disable-line rule:line-length
         description: "release-drafter config file under .github/ used for labels"

--- a/.github/workflows/reuse-issue-id.yaml
+++ b/.github/workflows/reuse-issue-id.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -96,7 +96,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-package-hardening-audit.yaml
+++ b/.github/workflows/reuse-package-hardening-audit.yaml
@@ -55,7 +55,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
 # Default to no permissions; the job grants the minimum it needs.
 permissions: {}

--- a/.github/workflows/reuse-python-codeql.yaml
+++ b/.github/workflows/reuse-python-codeql.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-semantic-pull-request.yaml
+++ b/.github/workflows/reuse-semantic-pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-sha-pinned-actions.yaml
+++ b/.github/workflows/reuse-sha-pinned-actions.yaml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
       path_prefix:
         description: "Directory location containing project code"
         required: false

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-sonatype-lifecycle.yaml
+++ b/.github/workflows/reuse-sonatype-lifecycle.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-verify-github-actions.yaml
+++ b/.github/workflows/reuse-verify-github-actions.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-zizmor.yaml
+++ b/.github/workflows/reuse-zizmor.yaml
@@ -33,7 +33,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
       upload_sarif:
         # yamllint disable-line rule:line-length
         description: "Publish SARIF results to code scanning (default-branch pushes only)"

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -118,7 +118,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'


### PR DESCRIPTION
## Summary

Bumps the pinned harden-runner egress allow-list reference from the
`v0.1.1` commit (`18d9c44`) to the `v0.3.0` release commit (`ad6501e`)
of [`lfreleng-actions/.github`](https://github.com/lfreleng-actions/.github/releases/tag/v0.3.0).

The [`v0.3.0` `allow_list.txt`](https://github.com/lfreleng-actions/.github/blob/v0.3.0/.github/harden-runner/lfreleng-actions/allow_list.txt)
adds further approved egress endpoints required by recent workflow
changes (including additional Scorecard / Sigstore / package-registry
endpoints).

## Changes

Updates all 15 `config` / `harden_runner_config` references that point
at `allow_list.txt`, across the reusable and standalone workflows:

- `autolabeler.yaml`
- `reuse-autolabeler.yaml`
- `reuse-issue-id.yaml`
- `reuse-openssf-scorecard.yaml` (2)
- `reuse-package-hardening-audit.yaml`
- `reuse-python-codeql.yaml`
- `reuse-semantic-pull-request.yaml`
- `reuse-sha-pinned-actions.yaml`
- `reuse-sonarqube-cloud.yaml`
- `reuse-sonatype-lifecycle.yaml`
- `reuse-verify-github-actions.yaml`
- `reuse-zizmor.yaml`
- `zizmor.yaml` (2)

Each reference remains pinned to an immutable commit SHA, with the
trailing comment updated from `# v0.1.1` to `# v0.3.0`.

## Validation

- `pre-commit` hooks (yamllint, actionlint, GitHub Actions workflow
  linters, reuse, codespell) pass locally.
