### PR TITLE
Feat: add change-isolation-verify workflows

### DIFF
--- a/.github/workflows/compose-change-isolation-verify-testing.yaml
+++ b/.github/workflows/compose-change-isolation-verify-testing.yaml
@@ -1,0 +1,135 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: Gerrit Compose Required Change Isolation Verify (Test version)
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: true
+        type: string
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: compose-required-isolation-test-${{ github.workflow }}-${{ inputs.GERRIT_BRANCH }}-${{ inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  isolation-validation:
+    name: Verify change isolation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/checkout-gerrit-change-action@f87b90a3370e62dad310797fedc7fd3700c75832  # v1.0.2
+        with:
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-project: ${{ inputs.GERRIT_PROJECT }}
+          gerrit-url: ${{ vars.GERRIT_URL }}
+          delay: "0s"
+          repository: ${{ inputs.TARGET_REPO }}
+          ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+      # yamllint disable-line rule:line-length
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        id: setup-python
+        with:
+          python-version: "3.11"
+      # INFO.yaml changes must remain isolated to a single, dedicated
+      # Gerrit change. The /INFO.yaml pattern anchors to the repository
+      # root so only the top-level INFO.yaml triggers the requirement.
+      - name: "Isolate INFO.yaml changes"
+        id: info-isolation
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        with:
+          paths: "/INFO.yaml"
+      # CI/CD changes under .github must likewise remain isolated. This
+      # runs even when the INFO.yaml check above fails so the change
+      # author receives both isolation results for a single patchset.
+      - name: "Isolate .github (CI/CD) changes"
+        id: github-isolation
+        if: ${{ !cancelled() }}
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        with:
+          paths: ".github/**"
+      # yamllint disable rule:line-length
+      - name: Download Valid Schema
+        if: steps.info-isolation.outputs.scanned == 'true'
+        # Download info-schema.yaml and yaml-verify-schema.py
+        run: |
+          wget -q https://raw.githubusercontent.com/lfit/releng-global-jjb/master/schema/info-schema.yaml \
+          https://raw.githubusercontent.com/lfit/releng-global-jjb/master/yaml-verify-schema.py
+      - name: Info File Validation
+        if: steps.info-isolation.outputs.scanned == 'true'
+        env:
+          PROJECT_INPUT: ${{ inputs.GERRIT_PROJECT }}
+        run: |
+          set -e -o pipefail
+          pip install jsonschema yq
+          yamllint INFO.yaml
+          python yaml-verify-schema.py \
+              -s info-schema.yaml \
+              -y INFO.yaml
+          # Verify that there is exactly one repository and that it matches $PROJECT_INPUT
+          REPO_LIST="$(yq -r '.repositories[]' INFO.yaml)"
+          REPO_COUNT="$(printf '%s\n' "$REPO_LIST" | grep -c . || true)"
+          if [[ "$REPO_COUNT" -ne 1 ]]; then
+              echo "ERROR: INFO.yaml must list exactly one repository"
+              echo "Found $REPO_COUNT repositories"
+              exit 1
+          fi
+          while IFS= read -r project; do
+              if [[ "$project" == "$PROJECT_INPUT" ]]; then
+                  echo "$project is valid"
+              else
+                  echo "ERROR: $project is invalid"
+                  echo "INFO.yaml file may only list one repository"
+                  echo "Repository must match $PROJECT_INPUT"
+                  exit 1
+              fi
+          done <<< "$REPO_LIST"

--- a/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml
@@ -1,0 +1,138 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: Gerrit Compose Required Change Isolation Verify
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: true
+        type: string
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: compose-required-isolation-${{ github.workflow }}-${{ inputs.GERRIT_BRANCH }}-${{ inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  isolation-validation:
+    name: Verify change isolation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Gerrit Checkout
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/checkout-gerrit-change-action@f87b90a3370e62dad310797fedc7fd3700c75832  # v1.0.2
+        with:
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-project: ${{ inputs.GERRIT_PROJECT }}
+          gerrit-url: ${{ vars.GERRIT_URL }}
+          delay: "0s"
+          repository: ${{ inputs.TARGET_REPO }}
+          ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+      # yamllint disable-line rule:line-length
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        id: setup-python
+        with:
+          python-version: "3.11"
+      # INFO.yaml changes must remain isolated to a single, dedicated
+      # Gerrit change. The /INFO.yaml pattern anchors to the repository
+      # root so only the top-level INFO.yaml triggers the requirement.
+      - name: "Isolate INFO.yaml changes"
+        id: info-isolation
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        with:
+          paths: "/INFO.yaml"
+      # CI/CD changes under .github must likewise remain isolated. This
+      # runs even when the INFO.yaml check above fails so the change
+      # author receives both isolation results for a single patchset.
+      - name: "Isolate .github (CI/CD) changes"
+        id: github-isolation
+        if: ${{ !cancelled() }}
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        with:
+          paths: ".github/**"
+      # yamllint disable rule:line-length
+      - name: Download Valid Schema
+        if: steps.info-isolation.outputs.scanned == 'true'
+        # Download info-schema.yaml and yaml-verify-schema.py
+        run: |
+          wget -q https://raw.githubusercontent.com/lfit/releng-global-jjb/master/schema/info-schema.yaml \
+          https://raw.githubusercontent.com/lfit/releng-global-jjb/master/yaml-verify-schema.py
+      - name: Info File Validation
+        if: steps.info-isolation.outputs.scanned == 'true'
+        env:
+          PROJECT_INPUT: ${{ inputs.GERRIT_PROJECT }}
+        run: |
+          set -e -o pipefail
+          pip install jsonschema yq
+          yamllint INFO.yaml
+          python yaml-verify-schema.py \
+              -s info-schema.yaml \
+              -y INFO.yaml
+          # Verify that there is only one repository and that it matches $PROJECT_INPUT
+          # Support subproject repos (e.g. integration/distribution) where
+          # INFO.yaml lists the parent project (e.g. integration)
+          REPO_LIST="$(yq -r '.repositories[]' INFO.yaml)"
+          REPO_COUNT="$(printf '%s\n' "$REPO_LIST" | grep -c . || true)"
+          if [[ "$REPO_COUNT" -ne 1 ]]; then
+              echo "ERROR: INFO.yaml must list exactly one repository"
+              echo "Found $REPO_COUNT repositories"
+              exit 1
+          fi
+          while IFS= read -r project; do
+              if [[ "$project" == "$PROJECT_INPUT" || "$PROJECT_INPUT" == "$project/"* ]]; then
+                  echo "$project is valid"
+              else
+                  echo "ERROR: $project is invalid"
+                  echo "INFO.yaml file may only list one repository"
+                  echo "Repository must match $PROJECT_INPUT"
+                  exit 1
+              fi
+          done <<< "$REPO_LIST"

--- a/.github/workflows/gerrit-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-required-change-isolation-verify.yaml
@@ -1,0 +1,193 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: Gerrit Required Change Isolation Verify
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: true
+        type: string
+      comment-only:
+        description: "Make this workflow advisory only, default false"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      GERRIT_SSH_REQUIRED_PRIVKEY:
+        description: "SSH Key for the authorized user account"
+        required: true
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: reusable-${{ github.workflow }}-${{ inputs.GERRIT_BRANCH }}-${{ inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  prepare:
+    name: Clear votes and prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear votes
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a5de1d5bf17c2603ae81544dc2a455017b454ec8 # v1.1.1
+        with:
+          host: ${{ vars.GERRIT_SERVER }}
+          username: ${{ vars.GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: clear
+          comment-only: ${{ inputs['comment-only'] }}
+      - name: Allow replication
+        run: sleep 10s
+
+  isolation-validation:
+    name: Verify change isolation
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Gerrit Checkout
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/checkout-gerrit-change-action@f87b90a3370e62dad310797fedc7fd3700c75832  # v1.0.2
+        with:
+          gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
+          gerrit-project: ${{ inputs.GERRIT_PROJECT }}
+          gerrit-url: ${{ vars.GERRIT_URL }}
+          delay: "0s"
+          repository: ${{ inputs.TARGET_REPO }}
+          ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+      # yamllint disable-line rule:line-length
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        id: setup-python
+        with:
+          python-version: "3.11"
+      # INFO.yaml changes must remain isolated to a single, dedicated
+      # Gerrit change. The /INFO.yaml pattern anchors to the repository
+      # root so only the top-level INFO.yaml triggers the requirement.
+      - name: "Isolate INFO.yaml changes"
+        id: info-isolation
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        with:
+          paths: "/INFO.yaml"
+      # CI/CD changes under .github must likewise remain isolated. This
+      # runs even when the INFO.yaml check above fails so the change
+      # author receives both isolation results for a single patchset.
+      - name: "Isolate .github (CI/CD) changes"
+        id: github-isolation
+        if: ${{ !cancelled() }}
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        with:
+          paths: ".github/**"
+      # yamllint disable rule:line-length
+      - name: Download Valid Schema
+        if: steps.info-isolation.outputs.scanned == 'true'
+        # Download info-schema.yaml and yaml-verify-schema.py
+        run: |
+          wget -q https://raw.githubusercontent.com/lfit/releng-global-jjb/master/schema/info-schema.yaml \
+          https://raw.githubusercontent.com/lfit/releng-global-jjb/master/yaml-verify-schema.py
+      - name: Info File Validation
+        if: steps.info-isolation.outputs.scanned == 'true'
+        env:
+          PROJECT_INPUT: ${{ inputs.GERRIT_PROJECT }}
+        run: |
+          set -e -o pipefail
+          pip install jsonschema yq
+          yamllint INFO.yaml
+          python yaml-verify-schema.py \
+              -s info-schema.yaml \
+              -y INFO.yaml
+          # Verify that there is only one repository and that it matches $PROJECT_INPUT
+          # Support subproject repos (e.g. integration/distribution) where
+          # INFO.yaml lists the parent project (e.g. integration)
+          REPO_LIST="$(yq -r '.repositories[]' INFO.yaml)"
+          REPO_COUNT="$(printf '%s\n' "$REPO_LIST" | grep -c . || true)"
+          if [[ "$REPO_COUNT" -ne 1 ]]; then
+              echo "ERROR: INFO.yaml must list exactly one repository"
+              echo "Found $REPO_COUNT repositories"
+              exit 1
+          fi
+          while IFS= read -r project; do
+              if [[ "$project" == "$PROJECT_INPUT" || "$PROJECT_INPUT" == "$project/"* ]]; then
+                  echo "$project is valid"
+              else
+                  echo "ERROR: $project is invalid"
+                  echo "INFO.yaml file may only list one repository"
+                  echo "Repository must match $PROJECT_INPUT"
+                  exit 1
+              fi
+          done <<< "$REPO_LIST"
+
+  vote:
+    name: Set Gerrit vote
+    if: ${{ always() }}
+    # yamllint enable rule:line-length
+    needs: [prepare, isolation-validation]
+    runs-on: ubuntu-latest
+    permissions:
+      # yamllint disable-line rule:line-length
+      actions: read  # workflow-conclusion reads this run's job statuses (Actions API)
+    steps:
+      - name: Get conclusion
+        # yamllint disable-line rule:line-length
+        uses: im-open/workflow-conclusion@8eac7f17381a6917bc04fec3e2c92e70ebc37526 # v3.0.0
+      - name: Set vote
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a5de1d5bf17c2603ae81544dc2a455017b454ec8 # v1.1.1
+        with:
+          host: ${{ vars.GERRIT_SERVER }}
+          username: ${{ vars.GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: ${{ env.WORKFLOW_CONCLUSION }}
+          comment-only: ${{ inputs['comment-only'] }}

--- a/docs/gerrit-compose-required-change-isolation-verify.rst
+++ b/docs/gerrit-compose-required-change-isolation-verify.rst
@@ -1,0 +1,90 @@
+.. _gerrit-compose-required-change-isolation-verify-docs:
+
+########################################################
+Gerrit Compose Required Change Isolation Verify Workflow
+########################################################
+
+The Gerrit Compose Required Change Isolation Verify Workflow verifies that a
+Gerrit change keeps its modifications isolated, and validates the top-level
+``INFO.yaml`` against the project schema when that file changes. It runs the
+validation alone; the calling workflow clears and sets Gerrit votes.
+
+This workflow supersedes the legacy
+``gerrit-compose-required-info-yaml-verify`` workflow. It isolates
+``INFO.yaml`` changes and ring-fences CI/CD changes under ``.github`` so
+that they are not combined with code or other content in the same change.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: None (Required)
+
+:Required secrets:
+
+    None. This workflow performs validation alone and does not vote in
+    Gerrit, so it requires no secrets. The calling workflow clears and
+    sets Gerrit votes.
+
+:Steps in the workflow:
+
+1. **Gerrit Checkout**:
+   The workflow checks out the specific Gerrit change based on the provided branch and refspec.
+
+2. **Isolate INFO.yaml changes**:
+   Uses the ``change-isolation-action`` with the ``/INFO.yaml`` pattern. The
+   leading slash anchors the pattern to the repository root, so the pattern
+   matches the top-level ``INFO.yaml`` and nothing nested.
+
+3. **Isolate .github (CI/CD) changes**:
+   Uses the ``change-isolation-action`` with the ``.github/**`` pattern. This
+   step runs even when the ``INFO.yaml`` check fails, so both isolation
+   results appear for a single patchset.
+
+4. **Download Valid Schema**:
+   If the change modifies ``INFO.yaml``, the workflow downloads the required
+   validation schema files (``info-schema.yaml`` and ``yaml-verify-schema.py``).
+
+5. **INFO.yaml File Check**:
+   The workflow uses ``yamllint`` and a Python script to check the ``INFO.yaml``
+   file, ensuring it follows the correct schema and contains the expected repository.
+
+The two isolation checks make the ``INFO.yaml`` and ``.github`` scopes
+mutually exclusive: a change that combines either scope with anything outside
+it fails.
+
+:Example usage:
+
+    - Trigger this workflow manually, from a calling workflow that handles
+      Gerrit voting, when a change requires verifying that ``INFO.yaml`` or
+      ``.github`` changes remain isolated.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Checkout the Gerrit change.
+    2. Verify that ``INFO.yaml`` changes remain isolated.
+    3. Verify that ``.github`` (CI/CD) changes remain isolated.
+    4. When ``INFO.yaml`` changed, download the schema files for validation.
+    5. Check the ``INFO.yaml`` file and confirm one matching repository.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2026 The Linux Foundation

--- a/docs/gerrit-required-change-isolation-verify.rst
+++ b/docs/gerrit-required-change-isolation-verify.rst
@@ -1,0 +1,108 @@
+.. _gerrit-required-change-isolation-verify-docs:
+
+################################################
+Gerrit Required Change Isolation Verify Workflow
+################################################
+
+
+The Gerrit Required Change Isolation Verify Workflow verifies that a Gerrit
+change keeps its modifications isolated. It enforces two mutually exclusive
+scopes and validates the top-level ``INFO.yaml`` against the project schema
+whenever that file changes, before merging.
+
+This workflow supersedes the legacy ``gerrit-required-info-yaml-verify``
+workflow. It isolates ``INFO.yaml`` changes and ring-fences CI/CD changes
+under ``.github`` so that they are not combined with code or other content
+in the same change.
+
+The workflow performs the following tasks:
+
+1. **Clear Votes**: Clears any existing votes on the Gerrit change to reset the status.
+2. **Gerrit Checkout**: Checks out the Gerrit change for the repository.
+3. **Isolate INFO.yaml changes**: Ensures that a change touching the top-level ``INFO.yaml`` changes no other file.
+4. **Isolate .github (CI/CD) changes**: Ensures that a change touching any file under ``.github`` changes nothing outside ``.github``.
+5. **Download Valid Schema**: When ``INFO.yaml`` changed, downloads a valid schema for the file and prepares for validation.
+6. **Info File Validation**: Validates the ``INFO.yaml`` file against the downloaded schema and checks its correctness.
+7. **Set Vote**: The workflow reports the result of the checks to Gerrit, updating the change status with the success or failure of the workflow.
+
+The two isolation checks make the ``INFO.yaml`` and ``.github`` scopes
+mutually exclusive: a change that combines either scope with anything outside
+it fails. Both checks always run, so the change author receives complete
+feedback for a single patchset.
+
+:Required parameters:
+
+    :GERRIT_BRANCH: The branch that the change targets.
+        Default: None (Required)
+    :GERRIT_CHANGE_ID: The unique identifier for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_NUMBER: The Gerrit number for the change.
+        Default: None (Required)
+    :GERRIT_CHANGE_URL: The URL to the change.
+        Default: None (Required)
+    :GERRIT_EVENT_TYPE: The Gerrit event triggering the workflow.
+        Default: None (Required)
+    :GERRIT_PATCHSET_NUMBER: The patch number for the change.
+        Default: None (Required)
+    :GERRIT_PATCHSET_REVISION: The revision SHA for the patchset.
+        Default: None (Required)
+    :GERRIT_PROJECT: The project in Gerrit for the change.
+        Default: None (Required)
+    :GERRIT_REFSPEC: The refspec of the change in Gerrit.
+        Default: None (Required)
+    :TARGET_REPO: The target GitHub repository needing the required workflow.
+        Default: None (Required)
+
+:Required secrets:
+
+    :secrets.GERRIT_SSH_REQUIRED_PRIVKEY:
+        The SSH private key for the authorized user account used to
+        interact with Gerrit.
+
+:Steps in the workflow:
+
+1. **Clear Votes**:
+   Clears any existing votes and notifies the start of the job on the Gerrit change.
+
+2. **Gerrit Checkout**:
+   The workflow checks out the specified Gerrit change and prepares the repository.
+
+3. **Isolate INFO.yaml changes**:
+   Uses the ``change-isolation-action`` with the ``/INFO.yaml`` pattern. The
+   leading slash anchors the pattern to the repository root, so the pattern
+   matches the top-level ``INFO.yaml`` and nothing nested.
+
+4. **Isolate .github (CI/CD) changes**:
+   Uses the ``change-isolation-action`` with the ``.github/**`` pattern. This
+   step runs even when the ``INFO.yaml`` check fails, so both isolation
+   results appear for a single patchset.
+
+5. **Download Valid Schema**:
+   If the change modifies ``INFO.yaml``, the workflow downloads a valid schema
+   (``info-schema.yaml``) and a Python script (``yaml-verify-schema.py``) for validation.
+
+6. **Info File Validation**:
+   The ``INFO.yaml`` file undergoes validation against the downloaded schema using ``yamllint``
+   and ``python yaml-verify-schema.py`` to ensure that it adheres to the correct structure.
+
+7. **Set Vote**:
+   The workflow sets the Gerrit vote based on the success or failure of the validation.
+
+:Example usage:
+
+    - Trigger this workflow manually when a change in Gerrit requires
+      verifying that ``INFO.yaml`` or ``.github`` changes remain isolated.
+    - The workflow will check the change and provide feedback to Gerrit.
+
+:Comment Trigger: recheck|reverify
+
+:Workflow Steps Summary:
+
+    1. Clear any existing votes and notify the start of the job in Gerrit.
+    2. Ensure ``INFO.yaml`` changes remain isolated in a separate change.
+    3. Ensure ``.github`` (CI/CD) changes remain isolated in a separate change.
+    4. When ``INFO.yaml`` changed, download the valid schema and check the file.
+    5. Report the workflow conclusion back to Gerrit.
+
+..  # SPDX-License-Identifier: Apache-2.0
+    # SPDX-FileCopyrightText: Copyright 2026 The Linux Foundation


### PR DESCRIPTION
## What

Adds a new set of Gerrit verify workflows that delegate change isolation
to [`lfreleng-actions/change-isolation-action`](https://github.com/lfreleng-actions/change-isolation-action)
(`v0.1.0`, pinned to commit `c306341`), replacing the bespoke inline
shell isolation check carried by the legacy `info-yaml-verify`
workflows.

New files:

- `.github/workflows/gerrit-required-change-isolation-verify.yaml` —
  full variant with its own `prepare`/`vote` jobs (mirrors
  `gerrit-required-info-yaml-verify.yaml`).
- `.github/workflows/gerrit-compose-required-change-isolation-verify.yaml` —
  compose variant, validation only, caller handles voting (mirrors
  `gerrit-compose-required-info-yaml-verify.yaml`).
- `.github/workflows/compose-change-isolation-verify-testing.yaml` —
  test variant (mirrors `compose-info-yaml-verify-testing.yaml`).
- `docs/gerrit-required-change-isolation-verify.rst`,
  `docs/gerrit-compose-required-change-isolation-verify.rst`.

## How

Each workflow runs the action twice — against `/INFO.yaml` and
`.github/**` — making those two scopes **mutually exclusive**: a change
that combines either scope with content outside it fails. The
`.github` check runs with `if: ${{ !cancelled() }}` so **both** isolation
results are reported for a single patchset, even when the first fails.

The existing `INFO.yaml` schema validation is retained and gated on the
action&#39;s `scanned` output (replacing the old `SCAN` env flag). The
`/INFO.yaml` pattern is root-anchored, tightening the legacy loose
substring match to the top-level file the schema steps actually
validate.

## Why a new set (not a rename)

Renaming the existing workflows would break pinned consumers
(O-RAN-SC uses the full variant; ONAP and ODL use the compose variant).
This adds the new workflows alongside the legacy ones. The follow-up
plan: tag a release, migrate the `onap`/`oran`/`odl` `.github` callers
to the new workflow paths, then remove the legacy `info-yaml-verify`
workflows in a later, separately-released change.

## Secret interface refinement (compose + test variants)

The compose and test variants previously declared
`secrets.GERRIT_SSH_REQUIRED_PRIVKEY` as `required: true`, mirroring the
legacy `gerrit-compose-required-info-yaml-verify.yaml`. That declaration
is **unused** in those variants: they contain only an
`isolation-validation` job and never vote in Gerrit (the calling
workflow clears and sets votes). A `required: true` `workflow_call`
secret forces every caller to pass it, and GitHub Actions rejects a
caller that passes a secret the callee does not declare — so carrying an
unused required secret adds friction and is misleading.

This change removes the unused secret from both the compose and test
variants and updates the compose docs to state that no secrets are
required. The **full** variant keeps the secret because its
`prepare`/`vote` jobs genuinely use it. Because the new workflows have no
callers yet (those are written fresh when migrating `onap`/`oran`/`odl`),
this is a zero-risk tightening of the interface with no behavioural
change. Raised by Copilot review; applied rather than carried forward for
parity, since it produces a cleaner interface for the new callers.

## Notes

- All actions are SHA-pinned (commit SHAs, not tags).
- The `GERRIT_PROJECT` input is passed through `env:` in the
  schema-validation step to avoid template injection (`zizmor`
  template-injection finding, also latent in the legacy code).
- The hyphenated `comment-only` input is referenced with bracket
  notation (`inputs['comment-only']`) in the full variant; dot notation
  would be parsed as the subtraction `inputs.comment - only` and
  silently evaluate to `0` (a latent bug in the legacy workflow).
- Compatibility: a Gerrit change is a single commit whose parent is the
  already-fetched branch tip, so the action&#39;s default `base-ref: HEAD~1`
  resolves under the existing `checkout-gerrit-change-action`
  (`fetch-depth: 1`) — parity with the legacy `git diff HEAD~1`.
- Local validation: full `prek` hook suite (incl. `actionlint`,
  `yamllint`, SHA-pin linter, `write-good`, `reuse`) and `zizmor`
  at both `--persona=regular` and `--persona=auditor` all pass with
  zero findings.