### PR TITLE
Fix: Comply with OpenSSF Scorecard restrictions

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -97,7 +97,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-autolabeler.yaml
+++ b/.github/workflows/reuse-autolabeler.yaml
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
       config_name:
         # yamllint disable-line rule:line-length
         description: "release-drafter config file under .github/ used for labels"

--- a/.github/workflows/reuse-issue-id.yaml
+++ b/.github/workflows/reuse-issue-id.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -25,28 +25,37 @@ jobs:
       # contents: read
       # actions: read
     steps:
-      # Load the egress allow-list out-of-band from
-      # lfreleng-actions/.github and publish it as
-      # $CONNECTION_ALLOW_LIST for the harden-runner step below
-      # to consume in 'block' mode. Loading out-of-band means
-      # the workflow no longer depends on any org-level GitHub
-      # variable being exposed at runtime (org variables are
-      # unreachable from workflows triggered by PRs raised from
-      # forks, which previously forced a fallback to audit mode).
-      # yamllint disable-line rule:line-length
-      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
-        with:
-          # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
-
-      # Harden the runner with the just-loaded allow-list.
+      # ossf/scorecard-action publishing imposes strict workflow
+      # restrictions on THIS job (the one running scorecard-action):
+      # only actions/checkout, actions/upload-artifact,
+      # github/codeql-action/upload-sarif, ossf/scorecard-action and
+      # step-security/harden-runner are permitted as steps. The
+      # org-wide harden-runner-block-action loader CANNOT be used
+      # here; the publish API rejects the run with HTTP 400
+      # 'job has unallowed step: lfreleng-actions/harden-runner-block-action'.
+      # We therefore keep egress 'block' mode but pass an explicit,
+      # curated allow-list covering only the endpoints Scorecard
+      # itself needs, rather than loading the full org allow-list.
+      # See https://github.com/ossf/scorecard-action#workflow-restrictions
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
+          # Curated egress allow-list for ossf/scorecard-action only.
+          # Artifact and SARIF uploads use GitHub Actions control-plane
+          # endpoints that harden-runner permits by default.
           allowed-endpoints: >
-            ${{ env.CONNECTION_ALLOW_LIST }}
+            api.github.com:443
+            github.com:443
+            *.githubusercontent.com:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            www.bestpractices.dev:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            *.sigstore.dev:443
+            tuf-repo.github.com:443
+            prod.app-api.stepsecurity.io:443
 
       - name: "Checkout code"
         # yamllint disable-line rule:line-length
@@ -96,7 +105,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-package-hardening-audit.yaml
+++ b/.github/workflows/reuse-package-hardening-audit.yaml
@@ -55,7 +55,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
 # Default to no permissions; the job grants the minimum it needs.
 permissions: {}

--- a/.github/workflows/reuse-python-codeql.yaml
+++ b/.github/workflows/reuse-python-codeql.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-semantic-pull-request.yaml
+++ b/.github/workflows/reuse-semantic-pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-sha-pinned-actions.yaml
+++ b/.github/workflows/reuse-sha-pinned-actions.yaml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
       path_prefix:
         description: "Directory location containing project code"
         required: false

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-sonatype-lifecycle.yaml
+++ b/.github/workflows/reuse-sonatype-lifecycle.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-verify-github-actions.yaml
+++ b/.github/workflows/reuse-verify-github-actions.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-zizmor.yaml
+++ b/.github/workflows/reuse-zizmor.yaml
@@ -33,7 +33,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
       upload_sarif:
         # yamllint disable-line rule:line-length
         description: "Publish SARIF results to code scanning (default-branch pushes only)"

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -118,7 +118,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ad6501e25f5a30746ad50a77c663115ddc94dc62'  # v0.3.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'


### PR DESCRIPTION
## Problem

Every OpenSSF Scorecard run across the `lfreleng-actions` org has been
**failing since egress block mode was enabled** (commit `8b9dd61`,
shipped in `v0.6.0`). The scorecard scores still visible in tooling are
stale — they predate the regression.

Root cause, captured from a real run
(`lfreleng-actions/zizmor-scan-action`, `Run analysis` step):

```
http response 400 Bad Request
{"code":400,"message":"workflow verification failed: workflow verification failed:
 job has unallowed step: lfreleng-actions/harden-runner-block-action,
 see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

`ossf/scorecard-action` enforces strict
[workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)
on the job that runs it: only `actions/checkout`,
`actions/upload-artifact`, `github/codeql-action/upload-sarif`,
`ossf/scorecard-action` and `step-security/harden-runner` are permitted
as steps. Our `harden-runner-block-action` egress allow-list loader is
**not** on that list, so the publish API rejects the results and the job
fails. Importantly, block mode itself works fine — the scan completes,
signs and reaches publish; only the static workflow-structure check
fails.

## Changes

1. **Scan job** — remove the `harden-runner-block-action` loader. Keep
   `step-security/harden-runner` in `block` mode (it *is* on the allowed
   list) and pass an explicit, **curated** allow-list covering only the
   endpoints Scorecard needs:
   GitHub API, `*.githubusercontent.com`, OSV, OpenSSF best-practices,
   the scorecard publish API, sigstore signing (`*.sigstore.dev` +
   `tuf-repo.github.com`), OSS-Fuzz logs and the harden-runner control
   endpoint. Artifact/SARIF uploads use the GitHub Actions control plane
   that harden-runner permits by default.
2. **Link job** — unaffected by the restrictions (it does not run
   `scorecard-action`), so it keeps the centralised loader. Its pinned
   allow-list is bumped `v0.3.0 → v0.4.0`.
3. **Other block-mode reusables** — bump the same allow-list pin
   `v0.3.0 → v0.4.0` (adds `production.cloudfront.docker.com:443`, the
   Docker Hub CloudFront pull CDN). `v0.4.0` is a strict superset of
   `v0.3.0`.

## Validation

- `yamllint`, `actionlint`, the GitHub Actions Workflow Linter and the
  workflow validator all pass (prek).
- Functional validation intentionally deferred: once merged and tagged,
  validate on `zizmor-scan-action` (currently failing deterministically)
  and confirm a **green publish** before any wider rollout.

## Notes for reviewers

- The curated scan-job allow-list is deliberately minimal; please sanity
  check it against the endpoints Scorecard contacts. If the optional
  `Upload artifact` step is ever blocked under block mode, the fix is to
  add the Actions results/blob endpoint — flagged here so it can be
  watched during the `zizmor-scan-action` validation run.
- Residual transient failures from `api.scorecard.dev` downtime are out
  of our control and unrelated to this change.
