### PR TITLE
Fix: Allow api.deps.dev egress in Scorecard scan

### DIFF
--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -49,6 +49,7 @@ jobs:
             api.github.com:443
             github.com:443
             *.githubusercontent.com:443
+            api.deps.dev:443
             api.osv.dev:443
             api.scorecard.dev:443
             www.bestpractices.dev:443


### PR DESCRIPTION
## Purpose

Add `api.deps.dev:443` to the curated harden-runner egress allow-list in
the OpenSSF Scorecard **Scan** job so the action's dependency-related
checks are no longer silently blocked.

## Background

A manual run of the Scorecard workflow on `lfreleng-actions/zizmor-scan-action`
([run 28449347102](https://github.com/lfreleng-actions/zizmor-scan-action/actions/runs/28449347102))
showed an outbound call being blocked under the **Scan** summary:

```
Process    Destination       Port        Status      Timestamp
Unknown    api.deps.dev      443(https)  ❌ Blocked   Jun 30 2026 13:49:25
node       api.github.com    443         ✅ Allowed   Jun 30 2026 13:49:47
scorecard  api.scorecard.dev 443         ✅ Allowed   Jun 30 2026 13:49:42
```

`ossf/scorecard-action` queries deps.dev (Google Open Source Insights)
as a data source for its dependency-related checks (Pinned-Dependencies,
license and dependency analysis). The call shows process `Unknown`
because harden-runner cannot attribute the short-lived connection to a
named process, but it fires in the same window as the other
`scorecard-action` calls and belongs to the Scan job.

The Scan job deliberately uses an explicit, curated allow-list (it
cannot use the org-wide `harden-runner-block-action` loader — that step
is rejected by Scorecard's publish API), so the fix belongs here rather
than in the central `allow_list.txt`.

## Change

```diff
             api.github.com:443
             github.com:443
             *.githubusercontent.com:443
+            api.deps.dev:443
             api.osv.dev:443
             api.scorecard.dev:443
```

## Impact

The block did not fail publishing (`api.scorecard.dev` was allowed, so
the run went green), but it silently degraded the dependency checks.
Allowing `api.deps.dev` restores accurate scoring for those checks.

## Validation

- `prek run --all-files` equivalent on the changed file — all hooks pass.
- A companion change adds `api.deps.dev:443` to the central
  `lfreleng-actions/.github` `allow_list.txt` for consistency (it was
  missing there too), though that list is not consumed by this Scan job.
- After merge + a patch release, re-run the manual Scorecard workflow on
  `zizmor-scan-action` and confirm `api.deps.dev` shows ✅ Allowed
  before the wider rollout.
