### PR TITLE
Chore: Bump change-isolation-action to v0.2.0

### DIFF
--- a/.github/workflows/compose-change-isolation-verify-testing.yaml
+++ b/.github/workflows/compose-change-isolation-verify-testing.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: "Isolate INFO.yaml changes"
         id: info-isolation
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:
           paths: "/INFO.yaml"
       # CI/CD changes under .github must likewise remain isolated. This
@@ -94,18 +94,18 @@ jobs:
         id: github-isolation
         if: ${{ !cancelled() }}
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:
           paths: ".github/**"
       # yamllint disable rule:line-length
       - name: Download Valid Schema
-        if: steps.info-isolation.outputs.scanned == 'true'
+        if: steps.info-isolation.outputs.triggered == 'true'
         # Download info-schema.yaml and yaml-verify-schema.py
         run: |
           wget -q https://raw.githubusercontent.com/lfit/releng-global-jjb/master/schema/info-schema.yaml \
           https://raw.githubusercontent.com/lfit/releng-global-jjb/master/yaml-verify-schema.py
       - name: Info File Validation
-        if: steps.info-isolation.outputs.scanned == 'true'
+        if: steps.info-isolation.outputs.triggered == 'true'
         env:
           PROJECT_INPUT: ${{ inputs.GERRIT_PROJECT }}
         run: |

--- a/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: "Isolate INFO.yaml changes"
         id: info-isolation
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:
           paths: "/INFO.yaml"
       # CI/CD changes under .github must likewise remain isolated. This
@@ -95,18 +95,18 @@ jobs:
         id: github-isolation
         if: ${{ !cancelled() }}
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:
           paths: ".github/**"
       # yamllint disable rule:line-length
       - name: Download Valid Schema
-        if: steps.info-isolation.outputs.scanned == 'true'
+        if: steps.info-isolation.outputs.triggered == 'true'
         # Download info-schema.yaml and yaml-verify-schema.py
         run: |
           wget -q https://raw.githubusercontent.com/lfit/releng-global-jjb/master/schema/info-schema.yaml \
           https://raw.githubusercontent.com/lfit/releng-global-jjb/master/yaml-verify-schema.py
       - name: Info File Validation
-        if: steps.info-isolation.outputs.scanned == 'true'
+        if: steps.info-isolation.outputs.triggered == 'true'
         env:
           PROJECT_INPUT: ${{ inputs.GERRIT_PROJECT }}
         run: |

--- a/.github/workflows/gerrit-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-required-change-isolation-verify.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: "Isolate INFO.yaml changes"
         id: info-isolation
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:
           paths: "/INFO.yaml"
       # CI/CD changes under .github must likewise remain isolated. This
@@ -124,18 +124,18 @@ jobs:
         id: github-isolation
         if: ${{ !cancelled() }}
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/change-isolation-action@c306341947f8a600f4f070b81162f0033128e206  # v0.1.0
+        uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:
           paths: ".github/**"
       # yamllint disable rule:line-length
       - name: Download Valid Schema
-        if: steps.info-isolation.outputs.scanned == 'true'
+        if: steps.info-isolation.outputs.triggered == 'true'
         # Download info-schema.yaml and yaml-verify-schema.py
         run: |
           wget -q https://raw.githubusercontent.com/lfit/releng-global-jjb/master/schema/info-schema.yaml \
           https://raw.githubusercontent.com/lfit/releng-global-jjb/master/yaml-verify-schema.py
       - name: Info File Validation
-        if: steps.info-isolation.outputs.scanned == 'true'
+        if: steps.info-isolation.outputs.triggered == 'true'
         env:
           PROJECT_INPUT: ${{ inputs.GERRIT_PROJECT }}
         run: |


### PR DESCRIPTION
## Summary

Updates the three change-isolation workflows to consume
[lfreleng-actions/change-isolation-action v0.2.0](https://github.com/lfreleng-actions/change-isolation-action/releases/tag/v0.2.0)
(lfreleng-actions/change-isolation-action#15, merged):

- `compose-change-isolation-verify-testing.yaml`
- `gerrit-compose-required-change-isolation-verify.yaml`
- `gerrit-required-change-isolation-verify.yaml`

### Changes

- **Bump the action pin** (6 `uses:` lines) to
  `5c2b23154b856dca369edb7667dd4a37211e3a34`, the commit tagged
  `v0.2.0`. The new release renders the in-scope patterns in the step
  summary table, so the two invocations per job (`/INFO.yaml` and
  `.github/**`) produce distinguishable output, and the no-op pass is
  labelled explicitly: `✅ Isolated (no in-scope files changed; no-op)`.
- **Migrate `outputs.scanned` → `outputs.triggered`** (6 gating
  conditions): `scanned` is now a deprecated alias for the clearer
  `triggered` output (true when at least one changed file matched the
  in-scope patterns, i.e. the check engaged).

### Example new summary output

> **Result:** ✅ Isolated (no in-scope files changed; no-op)
>
> | Property | Value |
> | --- | --- |
> | In-scope patterns | `/INFO.yaml` |
> | In-scope files changed | 0 |
> | Out-of-scope files changed | 0 |
> | Triggered | false |

### Validation

- `yamllint` and `actionlint` clean on all three workflows
- Full pre-commit hook suite passed on commit

### Downstream

Once this merges and a release is tagged, consumers such as
`onap/.github` can bump their reusable-workflow pins to pick up the
improved reporting.