### PR TITLE
Chore: Bump egress allow-list pin to v0.6.0

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -97,7 +97,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-autolabeler.yaml
+++ b/.github/workflows/reuse-autolabeler.yaml
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
       config_name:
         # yamllint disable-line rule:line-length
         description: "release-drafter config file under .github/ used for labels"

--- a/.github/workflows/reuse-issue-id.yaml
+++ b/.github/workflows/reuse-issue-id.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-openssf-scorecard.yaml
+++ b/.github/workflows/reuse-openssf-scorecard.yaml
@@ -106,7 +106,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-package-hardening-audit.yaml
+++ b/.github/workflows/reuse-package-hardening-audit.yaml
@@ -55,7 +55,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
 # Default to no permissions; the job grants the minimum it needs.
 permissions: {}

--- a/.github/workflows/reuse-python-codeql.yaml
+++ b/.github/workflows/reuse-python-codeql.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-semantic-pull-request.yaml
+++ b/.github/workflows/reuse-semantic-pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-sha-pinned-actions.yaml
+++ b/.github/workflows/reuse-sha-pinned-actions.yaml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
       path_prefix:
         description: "Directory location containing project code"
         required: false

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-sonatype-lifecycle.yaml
+++ b/.github/workflows/reuse-sonatype-lifecycle.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-verify-github-actions.yaml
+++ b/.github/workflows/reuse-verify-github-actions.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/reuse-zizmor.yaml
+++ b/.github/workflows/reuse-zizmor.yaml
@@ -33,7 +33,7 @@ on:
         required: false
         type: string
         # yamllint disable-line rule:line-length
-        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
       upload_sarif:
         # yamllint disable-line rule:line-length
         description: "Publish SARIF results to code scanning (default-branch pushes only)"

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -118,7 +118,7 @@ jobs:
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
           # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@9daeea15f1cce57566d8c91ebaf24a4a190da2e2'  # v0.4.0
+          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@ca8ce369a97afc64b6895266f10df9b5f5969743'  # v0.6.0
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'


### PR DESCRIPTION
## Summary

Bumps the `lfreleng-actions/.github` harden-runner egress allow-list pin from **v0.4.0** (`9daeea15…`) to **v0.6.0** (`ca8ce369…`) across all workflows — 14 occurrences in 13 files.

## Why

The v0.6.0 release of `lfreleng-actions/.github` ([PR #109](https://github.com/lfreleng-actions/.github/pull/109)) adds the SonarQube Cloud egress endpoints:

- `*.sonarcloud.io:443`
- `sonarcloud.io:443`
- `binaries.sonarsource.com:443`
- `analysis-sensorcache-eu-central-1-prod.s3.amazonaws.com:443`
- `dna-visualization-scannerdata-eu-central-1-prod.s3.amazonaws.com:443`

`reuse-sonarqube-cloud.yaml` runs harden-runner in **block** mode, and without these endpoints every SonarQube Cloud scan fails at the build-wrapper/scanner download step:

```
curl: (7) Failed to connect to sonarcloud.io port 443 after 1 ms: Couldn't connect to server
```

Observed in the wild (onap/policy-opa-pdp scheduled scan):
https://github.com/onap/policy-opa-pdp/actions/runs/29568659838

## Validation

- All 14 occurrences updated consistently (`grep` verified zero remaining `9daeea15…` references)
- Pre-commit clean: yamllint, actionlint, GitHub Actions Workflow Linter, workflow schema validation

A new release should be tagged after merge so downstream callers (e.g. ONAP `security-audits.yaml` thin callers) can pin to it.