### PR TITLE
Chore: Bump sonarqube-cloud-scan-action to v1.2.1

### DIFF
--- a/.github/workflows/composed-autotools-sonar-cloud.yaml
+++ b/.github/workflows/composed-autotools-sonar-cloud.yaml
@@ -131,6 +131,6 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/lfit/releng-global-jjb/master/shell/autotools-sonarqube.sh | bash
       - name: Run Sonar Cloud scan
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/composed-cmake-sonar-cloud.yaml
+++ b/.github/workflows/composed-cmake-sonar-cloud.yaml
@@ -133,6 +133,6 @@ jobs:
           curl https://raw.githubusercontent.com/lfit/releng-global-jjb/master/shell/cmake-sonarqube.sh | bash
       - name: Run Sonar Cloud scan
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/composed-generic-sonar-cloud.yaml
+++ b/.github/workflows/composed-generic-sonar-cloud.yaml
@@ -123,6 +123,6 @@ jobs:
         run: ${{ inputs.PRE_BUILD_SCRIPT }}
       - name: Run Sonar Cloud scan
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/composed-go-sonar-cloud.yaml
+++ b/.github/workflows/composed-go-sonar-cloud.yaml
@@ -200,7 +200,7 @@ jobs:
 
       - name: "SonarQube Cloud Scan"
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         with:
           sonar_token: ${{ secrets.SONAR_TOKEN }}
           # The Gerrit change is already checked out by the step above.

--- a/.github/workflows/composed-prescan-sonar-cloud.yaml
+++ b/.github/workflows/composed-prescan-sonar-cloud.yaml
@@ -128,6 +128,6 @@ jobs:
         run: sh "$PRE_BUILD"
       - name: Run Sonar Cloud scan
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         with:
           sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/composed-tox-sonar-cloud.yaml
+++ b/.github/workflows/composed-tox-sonar-cloud.yaml
@@ -142,6 +142,6 @@ jobs:
     steps:
       - name: "SonarQube Cloud Scan"
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         with:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/reuse-sonarqube-cloud.yaml
+++ b/.github/workflows/reuse-sonarqube-cloud.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: "SonarQube Cloud Scan"
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/sonarqube-cloud-scan-action@6138cf1252b714849809c85854a576974f6436f2 # v1.1.1
+        uses: lfreleng-actions/sonarqube-cloud-scan-action@b8d74f08d2222acb4556b71f9f3cd3e80bc8109b # v1.2.1
         with:
           sonar_token: ${{ secrets.sonar_token }}
           sonar_root_cert: ${{ inputs.sonar_root_cert }}


### PR DESCRIPTION
## Summary

Advance the pinned `sonarqube-cloud-scan-action` from **v1.1.1** to **v1.2.1** across all seven SonarQube Cloud reusable workflows.

## Why

`sonarqube-cloud-scan-action` **v1.2.1** embeds `repository-metadata-action` v0.2.4, which moved its sub-actions (`actions/setup-python`, `astral-sh/setup-uv`) to **node24** runtimes. The previously released pin (v1.1.1) embedded node20 sub-actions, which surfaced Node 20 deprecation warnings in downstream scans (e.g. `onap/policy-opa-pdp`). It also carries the null-inputs Gerrit extractor fix.

## Files changed

- `composed-autotools-sonar-cloud.yaml`
- `composed-cmake-sonar-cloud.yaml`
- `composed-generic-sonar-cloud.yaml`
- `composed-go-sonar-cloud.yaml`
- `composed-prescan-sonar-cloud.yaml`
- `composed-tox-sonar-cloud.yaml`
- `reuse-sonarqube-cloud.yaml`

Each is a single-line SHA pin bump (`b8d74f0…` = commit for tag `v1.2.1`) with a matching `# v1.2.1` comment.

## Validation

Local pre-commit clean (`actionlint`, `yamllint`, workflow linters all pass).