### PR TITLE
Feat: Add PARALLEL input to rtdv3 verify workflow

### DIFF
--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -50,6 +50,12 @@ on:
         required: false
         default: ${{ github.repository }}
         type: string
+      PARALLEL:
+        # yamllint disable-line rule:line-length
+        description: "Run tox environments in parallel; set to 'false' to run serially and avoid races between environments sharing state"
+        required: false
+        default: "true"
+        type: string
     secrets:
       RTD_TOKEN:
         description: "RTD API user token"
@@ -66,7 +72,6 @@ env:
   TOX_ENVS: docs,docs-linkcheck
   TOX_DIR: docs/
   DOC_DIR: _build/html
-  PARALLEL: true
   DEFAULT_VERSION: latest
   MASTER_RTD_PROJECT: doc
 
@@ -253,6 +258,8 @@ jobs:
       - name: Running tox
         # yamllint disable rule:line-length
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}
+        env:
+          PARALLEL: ${{ inputs.PARALLEL }}
         run: |
           PATH="${GITHUB_WORKSPACE}/.local/bin:${PATH}"
 
@@ -269,7 +276,6 @@ jobs:
           #Useful debug
           tox --version
 
-          PARALLEL=${{ env.PARALLEL }}
           TOX_OPTIONS_LIST=""
           if [[ -n ${{ env.TOX_ENVS }} ]]; then
               TOX_OPTIONS_LIST=${TOX_OPTIONS_LIST}" -e ${{ env.TOX_ENVS }}"


### PR DESCRIPTION
## Summary

The documentation verify workflow (`gerrit-compose-required-rtdv3-verify.yaml`) hardcoded parallel tox execution (`--parallel auto`), running the `docs` and `docs-linkcheck` environments concurrently. When those environments share state outside tox — for example a docs `conf.py` that shells out to generate artefacts into common paths — the parallel runs can race and fail intermittently.

This exposes `PARALLEL` as a `workflow_call` input, matching the sibling `gerrit-compose-required-tox-verify.yaml` workflow, so consumers can set it to `"false"` and run environments serially as a workaround. The default remains `"true"`, preserving existing behaviour for all current callers.

## Motivation

An ONAP `cps` ReadTheDocs verify run failed exactly this way: both `docs` and `docs-linkcheck` invoked the repo's `docs/generate-openapi.sh` concurrently (via `conf.py`), racing on a shared generator JAR and output directories, producing a Sphinx `ConfigError`. The repo-side script is being made concurrency-safe separately, but a `PARALLEL: false` escape hatch in the shared workflow lets any consumer work around this class of race without waiting for a repo-side fix.

## Changes

- Add `PARALLEL` (`workflow_call` input, `type: string`, `required: false`, `default: "true"`).
- Remove the hardcoded `PARALLEL: true` from the workflow-level `env:` block.
- Reference `${{ inputs.PARALLEL }}` in the tox run step (same style as the sibling tox-verify workflow).

## Behaviour / compatibility

- No behaviour change for existing callers — the default preserves `--parallel auto`.
- Only the verify workflow is touched. The merge variant defines `PARALLEL`/`TOX_ENVS` in `env:` but does not run tox (it only triggers the RTD build), so it is intentionally left unchanged.

## Validation

- `yamllint`, `actionlint`, `reuse lint`, `check-jsonschema` GitHub workflow validation, and the gha-workflow-linter all pass locally via pre-commit.
