### PR TITLE
Fix: support private repos in change isolation

### DIFF
--- a/.github/workflows/compose-change-isolation-verify-testing.yaml
+++ b/.github/workflows/compose-change-isolation-verify-testing.yaml
@@ -49,6 +49,15 @@ on:
         description: "The target GitHub repository needing the required workflow"
         required: true
         type: string
+    secrets:
+      token:
+        # yamllint disable-line rule:line-length
+        description: >
+          Token used to check out TARGET_REPO; defaults to the job's
+          GITHUB_TOKEN. Callers must supply a token with read access when
+          TARGET_REPO is private, since GITHUB_TOKEN is scoped to the
+          calling repository only.
+        required: false
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -66,6 +75,7 @@ jobs:
     steps:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/checkout-gerrit-change-action@f87b90a3370e62dad310797fedc7fd3700c75832  # v1.0.2
+        id: checkout
         with:
           gerrit-refspec: ${{ inputs.GERRIT_REFSPEC }}
           gerrit-project: ${{ inputs.GERRIT_PROJECT }}
@@ -73,6 +83,7 @@ jobs:
           delay: "0s"
           repository: ${{ inputs.TARGET_REPO }}
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: setup-python
@@ -90,9 +101,12 @@ jobs:
       # CI/CD changes under .github must likewise remain isolated. This
       # runs even when the INFO.yaml check above fails so the change
       # author receives both isolation results for a single patchset.
+      # It stays gated on the checkout, however: without a work tree the
+      # check cannot resolve HEAD~1 and would bury the real failure
+      # under a misleading base-ref error.
       - name: "Isolate .github (CI/CD) changes"
         id: github-isolation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:

--- a/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml
@@ -49,6 +49,15 @@ on:
         description: "The target GitHub repository needing the required workflow"
         required: true
         type: string
+    secrets:
+      token:
+        # yamllint disable-line rule:line-length
+        description: >
+          Token used to check out TARGET_REPO; defaults to the job's
+          GITHUB_TOKEN. Callers must supply a token with read access when
+          TARGET_REPO is private, since GITHUB_TOKEN is scoped to the
+          calling repository only.
+        required: false
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -65,6 +74,7 @@ jobs:
       contents: read
     steps:
       - name: Gerrit Checkout
+        id: checkout
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/checkout-gerrit-change-action@f87b90a3370e62dad310797fedc7fd3700c75832  # v1.0.2
         with:
@@ -74,6 +84,7 @@ jobs:
           delay: "0s"
           repository: ${{ inputs.TARGET_REPO }}
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: setup-python
@@ -91,9 +102,12 @@ jobs:
       # CI/CD changes under .github must likewise remain isolated. This
       # runs even when the INFO.yaml check above fails so the change
       # author receives both isolation results for a single patchset.
+      # It stays gated on the checkout, however: without a work tree the
+      # check cannot resolve HEAD~1 and would bury the real failure
+      # under a misleading base-ref error.
       - name: "Isolate .github (CI/CD) changes"
         id: github-isolation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:

--- a/.github/workflows/gerrit-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-required-change-isolation-verify.yaml
@@ -58,6 +58,14 @@ on:
       GERRIT_SSH_REQUIRED_PRIVKEY:
         description: "SSH Key for the authorized user account"
         required: true
+      token:
+        # yamllint disable-line rule:line-length
+        description: >
+          Token used to check out TARGET_REPO; defaults to the job's
+          GITHUB_TOKEN. Callers must supply a token with read access when
+          TARGET_REPO is private, since GITHUB_TOKEN is scoped to the
+          calling repository only.
+        required: false
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -94,6 +102,7 @@ jobs:
       contents: read
     steps:
       - name: Gerrit Checkout
+        id: checkout
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/checkout-gerrit-change-action@f87b90a3370e62dad310797fedc7fd3700c75832  # v1.0.2
         with:
@@ -103,6 +112,7 @@ jobs:
           delay: "0s"
           repository: ${{ inputs.TARGET_REPO }}
           ref: refs/heads/${{ inputs.GERRIT_BRANCH }}
+          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
       # yamllint disable-line rule:line-length
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         id: setup-python
@@ -120,9 +130,12 @@ jobs:
       # CI/CD changes under .github must likewise remain isolated. This
       # runs even when the INFO.yaml check above fails so the change
       # author receives both isolation results for a single patchset.
+      # It stays gated on the checkout, however: without a work tree the
+      # check cannot resolve HEAD~1 and would bury the real failure
+      # under a misleading base-ref error.
       - name: "Isolate .github (CI/CD) changes"
         id: github-isolation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/change-isolation-action@5c2b23154b856dca369edb7667dd4a37211e3a34  # v0.2.0
         with:


### PR DESCRIPTION
## Problem

The change isolation verification fails for every **private** Gerrit-replicated repository. Example failure: [lfit/.github run #17](https://github.com/lfit/.github/actions/runs/30128825075) against `TARGET_REPO: lfit/lfcore-terraform`.

```
repository 'https://github.com/lfit/lfcore-terraform/' not found      (x3 retries)
The process '/usr/bin/git' failed with exit code 128
base-ref 'HEAD~1' could not be resolved to a commit. ...
Process completed with exit code 1
```

Every failed run of that workflow since it went live has the same cause and the same target repo.

## Root cause 1 — the checkout has no usable token

`Gerrit Checkout` passed no `token:`, so `checkout-gerrit-change-action` fell back to its `${{ github.token }}` default. That installation token is scoped to the **calling** repository, so it cannot read a private mirror and GitHub returns `404 not found`.

`lfit/lfcore-terraform` is private (`GET /repos/lfit/lfcore-terraform` → `200` authenticated, `404` anonymous), and it is not a one-off — **11 of 63 `lfit` repositories are private**, including exactly the `puppet-*` / `lfcore-*` / `ci-management` trees:

```
lfit/ci-management                 lfit/lfcore-tools-misc
lfit/internal-reusable-workflows   lfit/puppet-hiera
lfit/lf-gpg-verify-action          lfit/puppet-master
lfit/lfcore-ansible-playbooks      lfit/puppet-modules-local_fw
lfit/lfcore-terraform              lfit/puppet-modules-profile
                                   lfit/puppet-modules-role
```

The sibling `gerrit-required-verify.yaml` in `lfit/.github` already checks out this same set successfully — by passing an explicit token. These workflows simply never plumbed one through.

The action's Gerrit fallback cannot rescue it either: it only runs *after* `actions/checkout` succeeds, and the Gerrit project is ACL'd too (`https://gerrit.linuxfoundation.org/infra/lfcore-terraform` → `403` anonymous).

### Fix

Expose an optional `token` secret and pass it to the checkout, following the convention already established by `reuse-autolabeler.yaml`:

```yaml
    secrets:
      token:
        description: >
          Token used to check out TARGET_REPO; defaults to the job's
          GITHUB_TOKEN. ...
        required: false
```

```yaml
          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
```

Backwards compatible — callers targeting only public repositories need no change.

## Root cause 2 — the real error was masked

Actual step outcomes from the failing run:

```
2  failure  Gerrit Checkout
3  skipped  actions/setup-python
4  skipped  Isolate INFO.yaml changes
5  failure  Isolate .github (CI/CD) changes   ← ran anyway
6  skipped  Download Valid Schema
7  skipped  Info File Validation
```

`if: ${{ !cancelled() }}` remains true when an *earlier step failed*, so the `.github` isolation step executed against the empty `git init` skeleton `actions/checkout` leaves behind. `--is-inside-work-tree` returns `true`, `HEAD~1` does not resolve, and the step reported a misleading base-ref error that buried the actual checkout failure.

This defect is independent of the token problem: **any** failure of the checkout step produces the same misleading `HEAD~1` error in place of the real cause.

### Fix

```yaml
        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
```

This preserves the original intent — the `.github` check still runs when the *INFO.yaml* check fails, so authors get both isolation results for one patchset — while no longer running without a work tree.

## Scope

Both fixes are applied to all three copies of this workflow, which had drifted into identical clones:

- `gerrit-compose-required-change-isolation-verify.yaml`
- `gerrit-required-change-isolation-verify.yaml`
- `compose-change-isolation-verify-testing.yaml`

## Notes

- **`fetch-depth` is deliberately unchanged.** The action's error message suggests raising it, and I initially planned to. Testing showed it is not the problem: `git fetch` without `--depth` into a shallow clone fully deepens the fetched ref, so `HEAD~1` resolves from a `fetch-depth: 1` clone. Verified against four `refs/pull/*/head` refs based on varying ancestors — all resolved `HEAD~1`, with the shallow boundary staying at a single commit.
- Checked and found **not** broken: `vars.GERRIT_URL` resolves correctly (`https://gerrit.linuxfoundation.org/infra/`), and the `triggered` output gating the INFO.yaml validation does exist in the pinned `change-isolation-action` v0.2.0.

## Validation

- `zizmor --persona auditor` on all three workflows: **no findings** (clean before and after)
- `prek run` on the changed files: actionlint, yamllint, the GitHub Actions workflow linters, and REUSE all pass

## Note on the original consumer

The workflow that surfaced this is being removed from `lfit/.github`, so the companion PR there (lfit/.github#51) has been closed. These fixes still stand on their own for the remaining and future consumers of these reusable workflows.
