### PR TITLE
Fix: move rtdv3 merge off EOL Python 3.8

### DIFF
--- a/.github/workflows/compose-docker-release-verify.yaml
+++ b/.github/workflows/compose-docker-release-verify.yaml
@@ -126,7 +126,12 @@ jobs:
           echo "INFO: Processing container release"
           docker --version
 
-          pip install jsonschema twine yq readline
+          # argcomplete 3.7.1 (a yq dependency) declares requires_python
+          # >=3.8 but its source uses PEP 585 generics, so importing it
+          # raises TypeError on the Python 3.8 pinned by this job. The
+          # marker retires itself when this job moves off 3.8.
+          python -m pip install jsonschema twine yq readline \
+            'argcomplete<3.7.1; python_version < "3.9"'
 
           VERSION=$(yq -r ".container_release_tag" "${{ env.release_file }}")
 

--- a/.github/workflows/compose-docker-verify.yaml
+++ b/.github/workflows/compose-docker-verify.yaml
@@ -101,7 +101,11 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           echo "---> docker-get-container-tag"
-          pip install yq
+          # argcomplete 3.7.1 (a yq dependency) declares requires_python
+          # >=3.8 but its source uses PEP 585 generics, so importing it
+          # raises TypeError on the Python 3.8 pinned by this job. The
+          # marker retires itself when this job moves off 3.8.
+          python -m pip install yq 'argcomplete<3.7.1; python_version < "3.9"'
           tag=''
           if [[ ${{ inputs.CONTAINER_TAG_METHOD }} == "latest" ]]; then
               tag="latest"

--- a/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml
@@ -82,7 +82,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         id: setup-python
         with:
-          python-version: "3.8"
+          # This interpreter only runs lftools/yq to drive the Read the
+          # Docs API; it never builds the project's documentation, so it
+          # is unrelated to the Python version in the project's tox.ini
+          # or .readthedocs.yaml. It was pinned to 3.8, which reached
+          # end of life in October 2024 and consequently received a yq
+          # dependency that no longer imports on it.
+          python-version: "3.13"
       - name: Install graphviz
         # yamllint disable-line rule:line-length
         uses: tlylt/install-graphviz@b2201200d85f06f0189cb74d9b69208504cf12cd # v1.0.0
@@ -97,9 +103,11 @@ jobs:
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}
         run: |
           python -m pip install --upgrade pip
-          pip install lftools 'niet~=1.4.2' yq tox
+          # Invoke pip via the interpreter rather than PATH so these
+          # installs land in the interpreter configured above.
+          python -m pip install lftools 'niet~=1.4.2' yq tox
           # urllib3 needs to be pinned to avoid timeouts
-          pip install --upgrade urllib3~=1.26.15
+          python -m pip install --upgrade urllib3~=1.26.15
       - name: Running rtdv3
         # yamllint disable rule:line-length
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}

--- a/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
+++ b/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml
@@ -67,7 +67,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_PYTHON: 3.9
+  # Fallback only, used when a project sets neither [testenv:docs]
+  # basepython nor build.tools.python. Was 3.9, which reached end of
+  # life in October 2025.
+  DEFAULT_PYTHON: 3.13
   READTHEDOCS_FOUND: true
   TOX_ENVS: docs,docs-linkcheck
   TOX_DIR: docs/
@@ -252,9 +255,19 @@ jobs:
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}
         run: |
           python -m pip install --upgrade pip
-          pip install lftools 'niet~=1.4.2' yq tox
+          # This interpreter comes from the project's tox.ini or
+          # .readthedocs.yaml, so a consumer can still select an
+          # end-of-life Python here. argcomplete 3.7.1 (a yq dependency)
+          # declares requires_python >=3.8 but its source uses PEP 585
+          # generics, so importing it raises TypeError on 3.8. Constrain
+          # it for those projects only; the marker applies nowhere else
+          # and retires itself as projects move off 3.8.
+          # Invoke pip via the interpreter, not PATH: the marker is
+          # evaluated against whichever interpreter runs pip.
+          python -m pip install lftools 'niet~=1.4.2' yq tox \
+            'argcomplete<3.7.1; python_version < "3.9"'
           # urllib3 needs to be pinned to avoid timeouts
-          pip install --upgrade urllib3~=1.26.15
+          python -m pip install --upgrade urllib3~=1.26.15
       - name: Running tox
         # yamllint disable rule:line-length
         if: ${{ env.READTHEDOCS_FOUND == 'true' }}


### PR DESCRIPTION
## Problem

`argcomplete` **3.7.1** was published to PyPI at **15:03 UTC on 2026-08-04** and immediately broke every job that installs `yq` on Python 3.8, across all consuming projects.

The release declares `requires_python >=3.8`, but its source annotates with PEP 585 generics over `collections.abc` types, so simply *importing* it raises:

```
File ".../python3.8/site-packages/argcomplete/completers.py", line 30, in BaseCompleter
    ) -> Iterable[str]:
TypeError: 'ABCMeta' object is not subscriptable
```

`argcomplete` is a hard dependency of `yq` (`argcomplete>=1.8.1`).

## Blast radius

Four workflows install `yq` on Python 3.8:

| Workflow | Python | Uses `yq` for |
| -------- | ------ | ------------- |
| `gerrit-compose-required-rtdv3-merge.yaml` | `3.8` hardcoded | parsing `lftools rtd` output |
| `gerrit-compose-required-rtdv3-verify.yaml` | derived from project config | parsing `lftools rtd` output |
| `compose-docker-verify.yaml` | `3.8` hardcoded | reading `container-tag.yaml` |
| `compose-docker-release-verify.yaml` | `3.8` hardcoded | reading release files |

Observed in ONAP: [`onap/.github` run 30923735831](https://github.com/onap/.github/actions/runs/30923735831) failed at 15:21 UTC. The preceding `cps` merge at 14:26 UTC succeeded, having resolved `argcomplete-3.7.0`. The failure lands *after* the Read the Docs work has already succeeded — the log shows `Project exists in read the docs` and `subproject relationship already created` immediately before the traceback — which makes it read like a project-side regression when it is not.

## Fix

The interpreter version was the actual defect in the rtdv3 merge job, not just the dependency.

**`gerrit-compose-required-rtdv3-merge.yaml` — moved 3.8 → 3.13, no constraint needed.**
This job never runs `tox` or `sphinx`; it only makes `lftools rtd` API calls. Its `tox` install, its graphviz install, and its `TOX_ENVS` / `TOX_DIR` / `DOC_DIR` / `PARALLEL` env vars are all vestigial and unused. The interpreter is therefore pure *tooling*, unrelated to the Python version the project declares for its docs — an arbitrary pin left sitting on a release that reached end of life in **October 2024**. `lftools` declares `requires_python <3.14,>=3.8`, so 3.13 is supported.

**`gerrit-compose-required-rtdv3-verify.yaml` — constraint kept, fallback raised 3.9 → 3.13.**
Here the interpreter *is* project-derived (`[testenv:docs] basepython`, else `build.tools.python`), so a consumer can still legitimately select 3.8 and genuinely needs the constraint. The `DEFAULT_PYTHON` fallback was 3.9, itself end of life since **October 2025**.

**Both docker workflows — constraint only, 3.8 pin retained for now.**
These also install the obsolete `readline` PyPI package, a 2013-era C extension that no longer builds on current interpreters (verified: it fails to compile on 3.13). Moving them off 3.8 carries independent regression risk that does not belong in a fix for a live outage. Worth a follow-up.

The constraint uses a PEP 508 environment marker rather than an unconditional pin, so it applies only where it is needed and **retires itself** as jobs and projects move off 3.8 — no cleanup debt.

`pip` is now invoked as `python -m pip`. A marker is evaluated against whichever interpreter runs pip, so binding it to the configured interpreter matters more here than it would for a plain version pin.

## Verification

Reproduced and fixed on local environments:

| Scenario | Resolved | Result |
| -------- | -------- | ------ |
| `pip install yq` on 3.8.20 | `argcomplete 3.7.1` | `TypeError: 'ABCMeta' object is not subscriptable` |
| `pip install yq 'argcomplete<3.7.1; python_version < "3.9"'` on 3.8.20 | `argcomplete 3.7.0` | import OK, `yq -r .a` → `1` |
| `pip install lftools 'niet~=1.4.2' yq tox` on 3.12 / 3.13 | `argcomplete 3.7.1` unpinned | `yq` OK, `lftools rtd` CLI OK |
| `pip install jsonschema twine yq readline` on 3.13 | — | `readline` build fails (`cc` exit 1) — why those two workflows stay on 3.8 |

Also confirmed:

- `prek run --all-files` — all hooks pass (yamllint, actionlint, workflow validators).
- `zizmor --persona auditor` across all four files — **50 findings before, 50 after, delta NONE**. No new findings; the existing ones are pre-existing and out of scope.

## Note on consuming projects

ONAP `cps` is already correctly configured — `.readthedocs.yaml` sets `build.tools.python: "3.13"` and `docs/tox.ini` sets `basepython = python3.13`, and the verify workflow resolves 3.13 from them. No project-side change is needed; the EOL interpreter was imposed entirely by the merge workflow.

## Follow-up

- The `requires_python` metadata for argcomplete 3.7.1 is wrong. Worth reporting to [kislyuk/argcomplete](https://github.com/kislyuk/argcomplete).
- Eight further workflows still pin Python 3.8. They do not install `yq` so are unaffected by this outage, but they are on an EOL interpreter.
- Remove the obsolete `readline` install from `compose-docker-release-verify.yaml`, then move both docker workflows off 3.8.
- The unused `tox`/graphviz installs and `TOX_*` env vars in the rtdv3 merge workflow could be dropped.
